### PR TITLE
Fix checking for fallthrough attribute support for older compilers

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1135,21 +1135,21 @@ namespace jwt {
 				switch (str.size() % 4) {
 				case 1:
 					str += alphabet::base64url::fill();
-#ifdef __cpp_attributes
+#ifdef __has_cpp_attribute
 #if __has_cpp_attribute(fallthrough)
 					[[fallthrough]];
 #endif
 #endif
 				case 2:
 					str += alphabet::base64url::fill();
-#ifdef __cpp_attributes
+#ifdef __has_cpp_attribute
 #if __has_cpp_attribute(fallthrough)
 					[[fallthrough]];
 #endif
 #endif
 				case 3:
 					str += alphabet::base64url::fill();
-#ifdef __cpp_attributes  
+#ifdef __has_cpp_attribute
 #if __has_cpp_attribute(fallthrough)
 					[[fallthrough]];
 #endif


### PR DESCRIPTION
GCC 4.9 (tested on 4.9.3)  doesn't have __has_cpp_attribute.

Compilation fails with:

```
include/jwt-cpp/jwt.h:1139:24: error: missing binary operator before token "("
 #if __has_cpp_attribute(fallthrough)
                        ^
```
