### PR TITLE
Adding stream operators to jwt::claim

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -804,6 +804,15 @@ namespace jwt {
 		}
 
 		/**
+		 * Parse input stream into wrapped json object
+		 * \return input stream
+		 */
+		inline std::istream& operator>>(std::istream& is)
+		{
+			return is >> val;
+		}
+
+		/**
 		 * Get type of contained object
 		 * \return Type
 		 * \throws std::logic_error An internal error occured
@@ -1587,4 +1596,15 @@ namespace jwt {
 	decoded_jwt decode(const std::string& token) {
 		return decoded_jwt(token);
 	}
+}
+
+
+inline std::istream& operator>>(std::istream& is, jwt::claim c)
+{
+	return c.operator>>(is);
+}
+
+inline std::ostream& operator<<(std::ostream& os, jwt::claim c)
+{
+	return os << c.to_json();
 }

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1598,13 +1598,12 @@ namespace jwt {
 	}
 }
 
-
-inline std::istream& operator>>(std::istream& is, jwt::claim c)
+inline std::istream& operator>>(std::istream& is, jwt::claim& c)
 {
 	return c.operator>>(is);
 }
 
-inline std::ostream& operator<<(std::ostream& os, jwt::claim c)
+inline std::ostream& operator<<(std::ostream& os, const jwt::claim& c)
 {
 	return os << c.to_json();
 }

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -18,7 +18,7 @@
 #endif
 
 #ifndef JWT_CLAIM_EXPLICIT
-#define JWT_CLAIM_EXPLICIT 1
+#define JWT_CLAIM_EXPLICIT explicit
 #endif
 
 namespace jwt {
@@ -772,33 +772,18 @@ namespace jwt {
 		claim()
 			: val()
 		{}
-#if JWT_CLAIM_EXPLICIT
-		explicit claim(std::string s)
+		JWT_CLAIM_EXPLICIT claim(std::string s)
 			: val(std::move(s))
 		{}
-		explicit claim(const date& s)
+		JWT_CLAIM_EXPLICIT claim(const date& s)
 			: val(int64_t(std::chrono::system_clock::to_time_t(s)))
 		{}
-		explicit claim(const std::set<std::string>& s)
+		JWT_CLAIM_EXPLICIT claim(const std::set<std::string>& s)
 			: val(picojson::array(s.cbegin(), s.cend()))
 		{}
-		explicit claim(const picojson::value& val)
+		JWT_CLAIM_EXPLICIT claim(const picojson::value& val)
 			: val(val)
 		{}
-#else
-		claim(std::string s)
-			: val(std::move(s))
-		{}
-		claim(const date& s)
-			: val(int64_t(std::chrono::system_clock::to_time_t(s)))
-		{}
-		claim(const std::set<std::string>& s)
-			: val(picojson::array(s.cbegin(), s.cend()))
-		{}
-		claim(const picojson::value& val)
-			: val(val)
-		{}
-#endif
 
 		template<typename Iterator>
 		claim(Iterator start, Iterator end)


### PR DESCRIPTION
I also removed some error prone code duplication with the `explicit` keyword for claims