### PR TITLE
Adds a find_package to GTest when tests are ON.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSSL 1.0.2 REQUIRED)
+
+if(BUILD_TESTS)
+   find_package(GTest REQUIRED)
+endif()
+  
 if(EXTERNAL_PICOJSON)
    find_package(picojson REQUIRED)
 endif()


### PR DESCRIPTION
I was trying to compile the project in my Ubuntu 20.04 and got the error below: 
```
[ 14%] Building CXX object tests/CMakeFiles/jwt-cpp-test.dir/BaseTest.cpp.o
/home/faustocarva/gits/faustocarva/jwt-cpp/tests/BaseTest.cpp:1:10: fatal error: gtest/gtest.h: Arquivo ou diretório inexistente
    1 | #include <gtest/gtest.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [tests/CMakeFiles/jwt-cpp-test.dir/build.make:63: tests/CMakeFiles/jwt-cpp-test.dir/BaseTest.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:94: tests/CMakeFiles/jwt-cpp-test.dir/all] Error 2
make: *** [Makefile:130: all] Error 2

```

After this i found that my new machine did not have **GTest** installed. It would be cool if the **CMake** got this missing dependency, so i've made the change to **CMakeLists.txt** to require the package if the **BUILD_TESTS** is **On** (which is the default behavior).
Thanks.

