### PR TITLE
Compile examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,7 @@ script:
   - cmake .
   - make
   - ./tests/jwt-cpp-test
+  - make install
+  - cd example
+  - cmake .
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cmake .
   - make
   - ./tests/jwt-cpp-test
-  - make install
+  - sudo make install
   - cd example
   - cmake .
   - make

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ auto token = jwt::create()
 	.sign(jwt::algorithm::hs256{"secret"});
 ```
 
+> To see more examples working with RSA public and private keys, visit our [examples](example)!
+
 ## Contributing
 If you have an improvement or found a bug feel free to [open an issue](https://github.com/Thalhammer/jwt-cpp/issues/new) or add the change and create a pull request. If you file a bug please make sure to include as much information about your environment (compiler version, etc.) as possible to help reproduce the issue. If you add a new feature please make sure to also include test cases for it.
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -8,3 +8,6 @@ target_link_libraries(print-claims jwt-cpp::jwt-cpp)
 
 add_executable(rsa-create rsa-create.cpp)
 target_link_libraries(rsa-create jwt-cpp::jwt-cpp)
+
+add_executable(rsa-verify rsa-verify.cpp)
+target_link_libraries(rsa-verify jwt-cpp::jwt-cpp)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
-include(${CMAKE_TOOLCHAIN_FILE})
 
-project(jwt-cpp-test)
+project(jwt-cpp-examples)
 find_package(jwt-cpp CONFIG REQUIRED)
 
-add_executable(jwt-cpp-test print-claims.cpp)
-target_link_libraries(jwt-cpp-test jwt-cpp::jwt-cpp)
+add_executable(print-claims print-claims.cpp)
+target_link_libraries(print-claims jwt-cpp::jwt-cpp)
+
+add_executable(rsa-create rsa-create.cpp)
+target_link_libraries(rsa-create jwt-cpp::jwt-cpp)

--- a/example/README.md
+++ b/example/README.md
@@ -1,8 +1,0 @@
-# Print Claims Example
-
-Simple demo showing the usage along with vcpkg.
-
-```sh
-cmake -DVCPKG_TARGET_TRIPLET=x64-linux -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/vcpkg/scripts/buildsystems/vcpkg.cmake .
-make
-```

--- a/example/rsa-create.cpp
+++ b/example/rsa-create.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <jwt-cpp/jwt.h>
+
+int main(int argc, const char **argv) {
+  std::string rsa_priv_key = R"(-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC4ZtdaIrd1BPIJ
+tfnF0TjIK5inQAXZ3XlCrUlJdP+XHwIRxdv1FsN12XyMYO/6ymLmo9ryoQeIrsXB
+XYqlET3zfAY+diwCb0HEsVvhisthwMU4gZQu6TYW2s9LnXZB5rVtcBK69hcSlA2k
+ZudMZWxZcj0L7KMfO2rIvaHw/qaVOE9j0T257Z8Kp2CLF9MUgX0ObhIsdumFRLaL
+DvDUmBPr2zuh/34j2XmWwn1yjN/WvGtdfhXW79Ki1S40HcWnygHgLV8sESFKUxxQ
+mKvPUTwDOIwLFL5WtE8Mz7N++kgmDcmWMCHc8kcOIu73Ta/3D4imW7VbKgHZo9+K
+3ESFE3RjAgMBAAECggEBAJTEIyjMqUT24G2FKiS1TiHvShBkTlQdoR5xvpZMlYbN
+tVWxUmrAGqCQ/TIjYnfpnzCDMLhdwT48Ab6mQJw69MfiXwc1PvwX1e9hRscGul36
+ryGPKIVQEBsQG/zc4/L2tZe8ut+qeaK7XuYrPp8bk/X1e9qK5m7j+JpKosNSLgJj
+NIbYsBkG2Mlq671irKYj2hVZeaBQmWmZxK4fw0Istz2WfN5nUKUeJhTwpR+JLUg4
+ELYYoB7EO0Cej9UBG30hbgu4RyXA+VbptJ+H042K5QJROUbtnLWuuWosZ5ATldwO
+u03dIXL0SH0ao5NcWBzxU4F2sBXZRGP2x/jiSLHcqoECgYEA4qD7mXQpu1b8XO8U
+6abpKloJCatSAHzjgdR2eRDRx5PMvloipfwqA77pnbjTUFajqWQgOXsDTCjcdQui
+wf5XAaWu+TeAVTytLQbSiTsBhrnoqVrr3RoyDQmdnwHT8aCMouOgcC5thP9vQ8Us
+rVdjvRRbnJpg3BeSNimH+u9AHgsCgYEA0EzcbOltCWPHRAY7B3Ge/AKBjBQr86Kv
+TdpTlxePBDVIlH+BM6oct2gaSZZoHbqPjbq5v7yf0fKVcXE4bSVgqfDJ/sZQu9Lp
+PTeV7wkk0OsAMKk7QukEpPno5q6tOTNnFecpUhVLLlqbfqkB2baYYwLJR3IRzboJ
+FQbLY93E8gkCgYB+zlC5VlQbbNqcLXJoImqItgQkkuW5PCgYdwcrSov2ve5r/Acz
+FNt1aRdSlx4176R3nXyibQA1Vw+ztiUFowiP9WLoM3PtPZwwe4bGHmwGNHPIfwVG
+m+exf9XgKKespYbLhc45tuC08DATnXoYK7O1EnUINSFJRS8cezSI5eHcbQKBgQDC
+PgqHXZ2aVftqCc1eAaxaIRQhRmY+CgUjumaczRFGwVFveP9I6Gdi+Kca3DE3F9Pq
+PKgejo0SwP5vDT+rOGHN14bmGJUMsX9i4MTmZUZ5s8s3lXh3ysfT+GAhTd6nKrIE
+kM3Nh6HWFhROptfc6BNusRh1kX/cspDplK5x8EpJ0QKBgQDWFg6S2je0KtbV5PYe
+RultUEe2C0jYMDQx+JYxbPmtcopvZQrFEur3WKVuLy5UAy7EBvwMnZwIG7OOohJb
+vkSpADK6VPn9lbqq7O8cTedEHttm6otmLt8ZyEl3hZMaL3hbuRj6ysjmoFKx6CrX
+rK0/Ikt5ybqUzKCMJZg2VKGTxg==
+-----END PRIVATE KEY-----)";
+  std::string rsa_pub_key = R"(-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuGbXWiK3dQTyCbX5xdE4
+yCuYp0AF2d15Qq1JSXT/lx8CEcXb9RbDddl8jGDv+spi5qPa8qEHiK7FwV2KpRE9
+83wGPnYsAm9BxLFb4YrLYcDFOIGULuk2FtrPS512Qea1bXASuvYXEpQNpGbnTGVs
+WXI9C+yjHztqyL2h8P6mlThPY9E9ue2fCqdgixfTFIF9Dm4SLHbphUS2iw7w1JgT
+69s7of9+I9l5lsJ9cozf1rxrXX4V1u/SotUuNB3Fp8oB4C1fLBEhSlMcUJirz1E8
+AziMCxS+VrRPDM+zfvpIJg3JljAh3PJHDiLu902v9w+Iplu1WyoB2aPfitxEhRN0
+YwIDAQAB
+-----END PUBLIC KEY-----)";
+
+  auto token =
+      jwt::create()
+          .set_issuer("auth0")
+          .set_type("JWT")
+          .set_id("rsa-create-example")
+          .set_issued_at(std::chrono::system_clock::now())
+          .sign(jwt::algorithm::rs256(rsa_pub_key, rsa_priv_key, "", ""));
+
+  std::cout << "token:\n" << token << std::endl;
+}

--- a/example/rsa-create.cpp
+++ b/example/rsa-create.cpp
@@ -46,6 +46,8 @@ YwIDAQAB
           .set_type("JWT")
           .set_id("rsa-create-example")
           .set_issued_at(std::chrono::system_clock::now())
+          .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{36000})
+          .set_payload_claim("sample", jwt::claim(std::string{"test"}))
           .sign(jwt::algorithm::rs256(rsa_pub_key, rsa_priv_key, "", ""));
 
   std::cout << "token:\n" << token << std::endl;

--- a/example/rsa-verify.cpp
+++ b/example/rsa-verify.cpp
@@ -55,7 +55,12 @@ YwIDAQAB
                         rsa_pub_key, rsa_priv_key, "", ""))
                     .with_issuer("auth0");
 
-  auto decoded_token = jwt::decode(token);
+  auto decoded = jwt::decode(token);
 
-  verify.verify(decoded_token);
+  verify.verify(decoded);
+
+  for (auto &e : decoded.get_header_claims())
+    std::cout << e.first << " = " << e.second.to_json() << std::endl;
+  for (auto &e : decoded.get_payload_claims())
+    std::cout << e.first << " = " << e.second.to_json() << std::endl;
 }

--- a/example/rsa-verify.cpp
+++ b/example/rsa-verify.cpp
@@ -40,13 +40,22 @@ AziMCxS+VrRPDM+zfvpIJg3JljAh3PJHDiLu902v9w+Iplu1WyoB2aPfitxEhRN0
 YwIDAQAB
 -----END PUBLIC KEY-----)";
 
-  auto token =
-      jwt::create()
-          .set_issuer("auth0")
-          .set_type("JWT")
-          .set_id("rsa-create-example")
-          .set_issued_at(std::chrono::system_clock::now())
-          .sign(jwt::algorithm::rs256(rsa_pub_key, rsa_priv_key, "", ""));
+  std::string token =
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9."
+      "VA2i1ui1cnoD6I3wnji1WAVCf29EekysvevGrT2GXqK1dDMc8"
+      "HAZCTQxa1Q8NppnpYV-hlqxh-X3Bb0JOePTGzjynpNZoJh2aHZD-"
+      "GKpZt7OO1Zp8AFWPZ3p8Cahq8536fD8RiBES9jRsvChZvOqA7gMcFc4"
+      "YD0iZhNIcI7a654u5yPYyTlf5kjR97prCf_OXWRn-bYY74zna4p_bP9oWCL4BkaoRcMxi-"
+      "IR7kmVcCnvbYqyIrKloXP2qPO442RBGqU7Ov9"
+      "sGQxiVqtRHKXZR9RbfvjrErY1KGiCp9M5i2bsUHadZEY44FE2jiOmx-"
+      "uc2z5c05CCXqVSpfCjWbh9gQ";
 
-  std::cout << "token:\n" << token << std::endl;
+  auto verify = jwt::verify()
+                    .allow_algorithm(jwt::algorithm::rs256(
+                        rsa_pub_key, rsa_priv_key, "", ""))
+                    .with_issuer("auth0");
+
+  auto decoded_token = jwt::decode(token);
+
+  verify.verify(decoded_token);
 }

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1440,8 +1440,8 @@ namespace jwt {
 				return res;
 			};
 
-			jwt::header<json_traits>::header_claims = parse_claims(header);
-			jwt::payload<json_traits>::payload_claims = parse_claims(payload);
+			this->header_claims = parse_claims(header);
+			this->payload_claims = parse_claims(payload);
 		}
 
 		/**
@@ -1479,7 +1479,20 @@ namespace jwt {
 		 * \return signature part before base64 decoding
 		 */
 		const typename json_traits::string_type& get_signature_base64() const noexcept { return signature_base64; }
-
+		/**
+		 * Get all payload claims
+		 * \return map of claims
+		 */
+		std::unordered_map<typename json_traits::string_type, basic_claim<json_traits>> get_payload_claims() const {
+			return this->payload_claims;
+		}
+		/**
+		 * Get all header claims
+		 * \return map of claims
+		 */
+		std::unordered_map<typename json_traits::string_type, basic_claim<json_traits>> get_header_claims() const {
+			return this->header_claims;
+		}
 	};
 
 	/**
@@ -1579,19 +1592,19 @@ namespace jwt {
 		 * \param d Expires time
 		 * \return *this to allow for method chaining
 		 */
-		builder& set_expires_at(const date& d) { return set_payload_claim("exp", typename json_traits::value_type(d)); }
+		builder& set_expires_at(const date& d) { return set_payload_claim("exp", basic_claim<json_traits>(d)); }
 		/**
 		 * Set not before claim
 		 * \param d First valid time
 		 * \return *this to allow for method chaining
 		 */
-		builder& set_not_before(const date& d) { return set_payload_claim("nbf", typename json_traits::value_type(d)); }
+		builder& set_not_before(const date& d) { return set_payload_claim("nbf", basic_claim<json_traits>(d)); }
 		/**
 		 * Set issued at claim
 		 * \param d Issued at time, should be current time
 		 * \return *this to allow for method chaining
 		 */
-		builder& set_issued_at(const date& d) { return set_payload_claim("iat", typename json_traits::value_type(d)); }
+		builder& set_issued_at(const date& d) { return set_payload_claim("iat", basic_claim<json_traits>(d)); }
 		/**
 		 * Set id claim
 		 * \param str ID to set


### PR DESCRIPTION
There was an API break introduced by #71 which makes the example in the README not compile \cc minjax

This will add the examples requested in #41 as well as test:
- the examples compile
- the cmake `find_package` is correct
