### PR TITLE
Generate doxygen documentation and publish on github pages + code coverage published on coveralls.io

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
         cmake .. -DBUILD_TESTS=ON -DCOVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
         
     - name: make
-      run: make jwt-cpp-test coverage
+      run: cd build && make jwt-cpp-test coverage
       
     - name: Coveralls GitHub Action
       uses: coverallsapp/github-action@v1.1.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,39 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: install cmake
+      uses: lukka/get-cmake@v3.17.2
+      
+    - name: configure
+      run: |
+        sudo apt update
+        sudo apt install libgtest-dev lcov
+        (cd /usr/src/gtest && sudo `which cmake` .)
+        sudo make -C /usr/src/gtest
+        sudo ln -s /usr/src/gtest/libgtest.a /usr/lib/libgtest.a
+        sudo ln -s /usr/src/gtest/libgtest_main.a /usr/lib/libgtest_main.a
+        mkdir build
+        cd build
+        cmake .. -DBUILD_TESTS=ON -DCOVERAGE=ON -DCMAKE_BUILD_TYPE=Debug
+        
+    - name: make
+      run: make jwt-cpp-test coverage
+      
+    - name: Coveralls GitHub Action
+      uses: coverallsapp/github-action@v1.1.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: build/coverage.info

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,8 +12,6 @@ jobs:
       
     - name: run doxygen
       uses: mattnotmitt/doxygen-action@v1
-      with:
-          doxyfile-path: 'docs/Doxygen'
    
     - name: deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,24 @@
+name: Documentation CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      
+    - name: run doxygen
+      uses: mattnotmitt/doxygen-action@v1
+      with:
+          working-directory: 'submodule/'
+          doxyfile-path: 'docs/Doxygen'
+   
+    - name: deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/html
+        force_orphan: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,7 +13,6 @@ jobs:
     - name: run doxygen
       uses: mattnotmitt/doxygen-action@v1
       with:
-          working-directory: 'submodule/'
           doxyfile-path: 'docs/Doxygen'
    
     - name: deploy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CMAKE_TOOLCHAIN_FILE)
 endif()
 
 option(BUILD_TESTS "Configure CMake to build tests (or not)" ON)
+option(COVERAGE "Enable code coverage testing" OFF)
 option(EXTERNAL_PICOJSON "Use find_package() to locate the picojson header" OFF)
 option(DISABLE_JWT_CPP_BASE64
        "Do not include the base64 implementation from this library" OFF)
@@ -15,6 +16,8 @@ project(jwt-cpp)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(OpenSSL 1.0.2 REQUIRED)
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "JWT-C++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = 0.5.0-dev
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -900,13 +900,13 @@ EXCLUDE_PATTERNS       = *nlohmann*, *picojson*
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = jwt::details
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           =
+EXAMPLE_PATH           = examples
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
@@ -1666,7 +1666,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/Doxyfile
+++ b/Doxyfile
@@ -889,7 +889,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = *nlohmann*, *picojson*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5f7055e294744901991fd0a1620b231d)](https://app.codacy.com/app/Thalhammer/jwt-cpp?utm_source=github.com&utm_medium=referral&utm_content=Thalhammer/jwt-cpp&utm_campaign=Badge_Grade_Settings)
 [![Build Status](https://travis-ci.com/Thalhammer/jwt-cpp.svg?branch=master)](https://travis-ci.com/Thalhammer/jwt-cpp)
+[![Coverage Status](https://coveralls.io/repos/github/prince-chrismc/jwt-cpp/badge.svg?branch=master)](https://coveralls.io/github/prince-chrismc/jwt-cpp?branch=master)
 
 A header only library for creating and validating json web tokens in c++.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5f7055e294744901991fd0a1620b231d)](https://app.codacy.com/app/Thalhammer/jwt-cpp?utm_source=github.com&utm_medium=referral&utm_content=Thalhammer/jwt-cpp&utm_campaign=Badge_Grade_Settings)
 [![Build Status](https://travis-ci.com/Thalhammer/jwt-cpp.svg?branch=master)](https://travis-ci.com/Thalhammer/jwt-cpp)
-[![Coverage Status](https://coveralls.io/repos/github/prince-chrismc/jwt-cpp/badge.svg?branch=master)](https://coveralls.io/github/prince-chrismc/jwt-cpp?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Thalhammer/jwt-cpp/badge.svg?branch=master)](https://coveralls.io/github/Thalhammer/jwt-cpp?branch=master)
 
 A header only library for creating and validating json web tokens in c++.
 

--- a/cmake/code-coverage.cmake
+++ b/cmake/code-coverage.cmake
@@ -1,0 +1,15 @@
+set(COVERAGE_CMAKE "${CMAKE_BINARY_DIR}/cmake/CodeCoverage.cmake")
+if(NOT EXISTS ${COVERAGE_CMAKE})
+  set(COVERAGE_URL
+      "https://raw.githubusercontent.com/bilke/cmake-modules/master/CodeCoverage.cmake"
+  )
+  file(DOWNLOAD ${COVERAGE_URL} ${COVERAGE_CMAKE})
+endif()
+
+include(${COVERAGE_CMAKE})
+
+function(setup_coverage TARGET)
+  target_compile_options(${TARGET} PRIVATE -g -O0 -fprofile-arcs
+                                           -ftest-coverage)
+  target_link_libraries(${TARGET} PRIVATE gcov)
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,3 +35,12 @@ target_link_libraries(jwt-cpp-test PRIVATE jwt-cpp::jwt-cpp GTest::GTest
                                            GTest::Main pthread)
 
 gtest_add_tests(TARGET jwt-cpp-test)
+
+if(${COVERAGE})
+  include("code-coverage")
+  setup_coverage(jwt-cpp-test)
+
+  set(COVERAGE_EXCLUDES "/usr/**" "/home/*/.conan/**" "*test*" "*build*" "*json*")
+  setup_target_for_coverage_lcov(NAME coverage EXECUTABLE
+                                 ${CMAKE_CURRENT_BINARY_DIR}/jwt-cpp-test)
+endif()


### PR DESCRIPTION
Since this library is used as a part of API security I think its only fair to expect a high level of quality.

Having documentation more accessibly helps prevent implementation mistakes.
Code coverage will help highlight short comings where improvements can be made.

closes #41 

- [ ] add link to gp-pages in `README.md` or project
- [ ] setup coveralls.io for upstream