### PR TITLE
dont install picojson when it's disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(
 target_link_libraries(jwt-cpp INTERFACE OpenSSL::SSL OpenSSL::Crypto)
 
 set(JWT_HEADERS ${JWT_INCLUDE_PATH}/jwt-cpp/base.h)
-if(NOT EXTERNAL_PICOJSON)
+if(NOT EXTERNAL_PICOJSON AND NOT DISABLE_JWT_CPP_PICOJSON)
   set(PICO_HEADER ${JWT_INCLUDE_PATH}/picojson/picojson.h)
 endif()
 


### PR DESCRIPTION
closes #68

with the new templating this extension makes sense to offer.

either `EXTERNAL_PICOJSON` or `DISABLE_JWT_CPP_PICOJSON` will prevent the install of picojson