### PR TITLE
Add virtual dtor to algo_base

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1692,6 +1692,7 @@ namespace jwt {
 	template<typename Clock, typename json_traits>
 	class verifier {
 		struct algo_base {
+			virtual ~algo_base() = default;
 			virtual void verify(const std::string& data, const std::string& sig) = 0;
 		};
 		template<typename T>


### PR DESCRIPTION
Otherwise, compilers will complain if verifier is used as a member variable.