### PR TITLE
:bookmark: set version to 0.5.0-rc.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ configure_package_config_file(
 
 write_basic_package_version_file(
   ${CMAKE_CURRENT_BINARY_DIR}/jwt-cpp-config-version.cmake
-  VERSION 0.5.0-dev
+  VERSION 0.5.0-rc.0
   COMPATIBILITY ExactVersion)
 
 install(FILES "${JWT_INCLUDE_PATH}/jwt-cpp/jwt.h" DESTINATION include/jwt-cpp)

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "JWT-C++"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.5.0-dev
+PROJECT_NUMBER         = 0.5.0-rc.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For the sake of completeness, here is a list of all supported algorithms:
 
 ## Overview
 
-Since 0.5.0-dev, there is no hard dependency on a JSON library; instead there's a generic `jwt::basic_claim` which is templated around the types required.It requires a traits type, which defines types for a value, object, array, string, number, integer and boolean, as well as methods to translate between them.
+Since 0.5.0-rc.0, there is no hard dependency on a JSON library; instead there's a generic `jwt::basic_claim` which is templated around the types required.It requires a traits type, which defines types for a value, object, array, string, number, integer and boolean, as well as methods to translate between them.
 
 ```cpp
 jwt::basic_claim<my_favorite_json_library_traits> claim(json::object({{"json", true},{"example", 0}}));


### PR DESCRIPTION
I would love to tag a pre-release so we could share the library's recent changes and get some feedback.

If you merge this PR, there a draft for the RC [here](https://github.com/Thalhammer/jwt-cpp/releases/tag/untagged-30029f2be088d41c8c7c) that either of us could publish :tada: 