### PR TITLE
Add helper function to convert cert from base64DER to PEM

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -397,6 +397,41 @@ namespace jwt {
 		}
 
 		/**
+		 * \brief Convert the cert provided as base64 DER to PEM. This useful when
+		 * using with JWKs as x5c claim is encoded as base64 DER. More info 
+		 * (here)[https://tools.ietf.org/html/rfc7517#section-4.7]
+		 * 
+		 * \param cert_base64_der_str String containing the certificate encoded as base64 DER
+		 * \throws rsa_exception if an error occurred
+		 */
+		inline
+		std::string convert_base64_der_to_pem(const std::string& cert_base64_der_str) {
+
+			auto decodedStr = base::decode<alphabet::base64>(base::pad<alphabet::base64>(cert_base64_der_str));
+			auto c_str = reinterpret_cast<const unsigned char *> (decodedStr.c_str());
+				
+			//
+			// d2i -> DER to internal x509 struct
+			//
+			std::unique_ptr<X509, decltype(&X509_free)> cert(d2i_X509(NULL, & c_str, decodedStr.size()), X509_free);
+			std::unique_ptr<BIO, decltype(&BIO_free_all)> certbio(BIO_new(BIO_s_mem()), BIO_free_all);
+			if(!cert || !certbio) {
+				throw rsa_exception(error::rsa_error::create_mem_bio_failed);
+			}
+
+			PEM_write_bio_X509(certbio.get(), cert.get());
+
+			char* ptr = nullptr;
+			auto len = BIO_get_mem_data(certbio.get(), &ptr);
+			if(len <= 0 || ptr == nullptr) {
+				throw rsa_exception(error::rsa_error::convert_to_pem_failed);
+			}
+
+			std::string cert_pem(ptr, len);
+			return cert_pem;
+		}
+
+		/**
 		 * \brief Load a public key from a string.
 		 * 
 		 * The string should contain a pem encoded certificate or public key

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -427,13 +427,13 @@ namespace jwt {
 			}
 
 			char* ptr = nullptr;
-			const uint64_t len = BIO_get_mem_data(certbio.get(), &ptr);
+			const auto len = BIO_get_mem_data(certbio.get(), &ptr);
 			if(len <= 0 || ptr == nullptr) {
 				ec = error::rsa_error::convert_to_pem_failed;
 				return {};
 			}
 
-			return std::string {ptr, len};
+			return std::string {ptr, static_cast<size_t>(len)};
 		}
 
 		/**

--- a/tests/ClaimTest.cpp
+++ b/tests/ClaimTest.cpp
@@ -59,7 +59,7 @@ TEST(ClaimTest, AudienceAsSet) {
 TEST(ClaimTest, SetAudienceAsSet) {
 	auto token = jwt::create()
 		.set_type("JWT")
-		.set_audience({picojson::value("test"), picojson::value("test2")})
+		.set_audience({{picojson::value("test"), picojson::value("test2")}})
 		.sign(jwt::algorithm::none{});
 	ASSERT_EQ("eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhdWQiOlsidGVzdCIsInRlc3QyIl19.", token);
 }

--- a/tests/HelperTest.cpp
+++ b/tests/HelperTest.cpp
@@ -39,7 +39,7 @@ TEST(HelperTest, ErrorCodeMessages) {
     ASSERT_EQ(std::error_code(jwt::error::token_verification_error::ok).category().name(), std::string("token_verification_error"));
 
     int i = 10;
-    for(i = 10; i < 18; i++) {
+    for(i = 10; i < 19; i++) {
         ASSERT_NE(std::error_code(static_cast<jwt::error::rsa_error>(i)).message(),
             std::error_code(static_cast<jwt::error::rsa_error>(-1)).message());
     }

--- a/tests/HelperTest.cpp
+++ b/tests/HelperTest.cpp
@@ -3,12 +3,18 @@
 
 namespace {
     extern std::string google_cert;
+    extern std::string google_cert_base64_der;
     extern std::string google_cert_key;
 }
 
 TEST(HelperTest, Cert2Pubkey) {
     auto key = jwt::helper::extract_pubkey_from_cert(google_cert);
     ASSERT_EQ(google_cert_key, key);
+}
+
+TEST(HelperTest, Base64DER2PemCert) {
+    auto cert_pem = jwt::helper::convert_base64_der_to_pem (google_cert_base64_der);
+    ASSERT_EQ(google_cert, cert_pem);
 }
 
 TEST(HelperTest, ErrorCodeMessages) {
@@ -39,28 +45,28 @@ TEST(HelperTest, ErrorCodeMessages) {
     }
     ASSERT_EQ(std::error_code(static_cast<jwt::error::rsa_error>(i)).message(),
         std::error_code(static_cast<jwt::error::rsa_error>(-1)).message());
-    
+
     for(i = 10; i < 16; i++) {
         ASSERT_NE(std::error_code(static_cast<jwt::error::ecdsa_error>(i)).message(),
             std::error_code(static_cast<jwt::error::ecdsa_error>(-1)).message());
     }
     ASSERT_EQ(std::error_code(static_cast<jwt::error::ecdsa_error>(i)).message(),
         std::error_code(static_cast<jwt::error::ecdsa_error>(-1)).message());
-    
+
     for(i = 10; i < 16; i++) {
         ASSERT_NE(std::error_code(static_cast<jwt::error::signature_verification_error>(i)).message(),
             std::error_code(static_cast<jwt::error::signature_verification_error>(-1)).message());
     }
     ASSERT_EQ(std::error_code(static_cast<jwt::error::signature_verification_error>(i)).message(),
         std::error_code(static_cast<jwt::error::signature_verification_error>(-1)).message());
-    
+
     for(i = 10; i < 22; i++) {
         ASSERT_NE(std::error_code(static_cast<jwt::error::signature_generation_error>(i)).message(),
             std::error_code(static_cast<jwt::error::signature_generation_error>(-1)).message());
     }
     ASSERT_EQ(std::error_code(static_cast<jwt::error::signature_generation_error>(i)).message(),
         std::error_code(static_cast<jwt::error::signature_generation_error>(-1)).message());
-    
+
     for(i = 10; i < 16; i++) {
         ASSERT_NE(std::error_code(static_cast<jwt::error::token_verification_error>(i)).message(),
             std::error_code(static_cast<jwt::error::token_verification_error>(-1)).message());
@@ -103,7 +109,42 @@ eW91dHViZS5jb22CFHlvdXR1YmVlZHVjYXRpb24uY29tMA0GCSqGSIb3DQEBBQUA
 A4GBAAMn0K3j3yhC+X+uyh6eABa2Eq7xiY5/mUB886Ir19vxluSMNKD6n/iY8vHj
 trn0BhuW8/vmJyudFkIcEDUYE4ivQMlsfIL7SOGw6OevVLmm02aiRHWj5T20Ds+S
 OpueYUG3NBcHP/5IzhUYIQJbGzlQaUaZBMaQeC8ZslMNLWI2
------END CERTIFICATE-----)";
+-----END CERTIFICATE-----
+)";
+
+    std::string google_cert_base64_der =
+        "MIIF8DCCBVmgAwIBAgIKYFOB9QABAACIvTANBgkqhkiG9w0BAQUFADBGMQswCQYD"
+        "VQQGEwJVUzETMBEGA1UEChMKR29vZ2xlIEluYzEiMCAGA1UEAxMZR29vZ2xlIElu"
+        "dGVybmV0IEF1dGhvcml0eTAeFw0xMzA1MjIxNTQ5MDRaFw0xMzEwMzEyMzU5NTla"
+        "MGYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1N"
+        "b3VudGFpbiBWaWV3MRMwEQYDVQQKEwpHb29nbGUgSW5jMRUwEwYDVQQDFAwqLmdv"
+        "b2dsZS5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARmSpIUbCqhUBq1UwnR"
+        "Ai7/TNSk6W8JmasR+I0r/NLDYv5yApbAz8HXXN8hDdurMRP6Jy1Q0UIKmyls8HPH"
+        "exoCo4IECjCCBAYwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAsGA1Ud"
+        "DwQEAwIHgDAdBgNVHQ4EFgQUU3jT0NVNRgU5ZinRHGrlyoGEnoYwHwYDVR0jBBgw"
+        "FoAUv8Aw6/VDET5nup6R+/xq2uNrEiQwWwYDVR0fBFQwUjBQoE6gTIZKaHR0cDov"
+        "L3d3dy5nc3RhdGljLmNvbS9Hb29nbGVJbnRlcm5ldEF1dGhvcml0eS9Hb29nbGVJ"
+        "bnRlcm5ldEF1dGhvcml0eS5jcmwwZgYIKwYBBQUHAQEEWjBYMFYGCCsGAQUFBzAC"
+        "hkpodHRwOi8vd3d3LmdzdGF0aWMuY29tL0dvb2dsZUludGVybmV0QXV0aG9yaXR5"
+        "L0dvb2dsZUludGVybmV0QXV0aG9yaXR5LmNydDAMBgNVHRMBAf8EAjAAMIICwwYD"
+        "VR0RBIICujCCAraCDCouZ29vZ2xlLmNvbYINKi5hbmRyb2lkLmNvbYIWKi5hcHBl"
+        "bmdpbmUuZ29vZ2xlLmNvbYISKi5jbG91ZC5nb29nbGUuY29tghYqLmdvb2dsZS1h"
+        "bmFseXRpY3MuY29tggsqLmdvb2dsZS5jYYILKi5nb29nbGUuY2yCDiouZ29vZ2xl"
+        "LmNvLmlugg4qLmdvb2dsZS5jby5qcIIOKi5nb29nbGUuY28udWuCDyouZ29vZ2xl"
+        "LmNvbS5hcoIPKi5nb29nbGUuY29tLmF1gg8qLmdvb2dsZS5jb20uYnKCDyouZ29v"
+        "Z2xlLmNvbS5jb4IPKi5nb29nbGUuY29tLm14gg8qLmdvb2dsZS5jb20udHKCDyou"
+        "Z29vZ2xlLmNvbS52boILKi5nb29nbGUuZGWCCyouZ29vZ2xlLmVzggsqLmdvb2ds"
+        "ZS5mcoILKi5nb29nbGUuaHWCCyouZ29vZ2xlLml0ggsqLmdvb2dsZS5ubIILKi5n"
+        "b29nbGUucGyCCyouZ29vZ2xlLnB0gg8qLmdvb2dsZWFwaXMuY26CFCouZ29vZ2xl"
+        "Y29tbWVyY2UuY29tgg0qLmdzdGF0aWMuY29tggwqLnVyY2hpbi5jb22CECoudXJs"
+        "Lmdvb2dsZS5jb22CFioueW91dHViZS1ub2Nvb2tpZS5jb22CDSoueW91dHViZS5j"
+        "b22CFioueW91dHViZWVkdWNhdGlvbi5jb22CCyoueXRpbWcuY29tggthbmRyb2lk"
+        "LmNvbYIEZy5jb4IGZ29vLmdsghRnb29nbGUtYW5hbHl0aWNzLmNvbYIKZ29vZ2xl"
+        "LmNvbYISZ29vZ2xlY29tbWVyY2UuY29tggp1cmNoaW4uY29tggh5b3V0dS5iZYIL"
+        "eW91dHViZS5jb22CFHlvdXR1YmVlZHVjYXRpb24uY29tMA0GCSqGSIb3DQEBBQUA"
+        "A4GBAAMn0K3j3yhC+X+uyh6eABa2Eq7xiY5/mUB886Ir19vxluSMNKD6n/iY8vHj"
+        "trn0BhuW8/vmJyudFkIcEDUYE4ivQMlsfIL7SOGw6OevVLmm02aiRHWj5T20Ds+S"
+        "OpueYUG3NBcHP/5IzhUYIQJbGzlQaUaZBMaQeC8ZslMNLWI2";
 
     std::string google_cert_key = R"(-----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZkqSFGwqoVAatVMJ0QIu/0zUpOlv

--- a/tests/Keys.cpp
+++ b/tests/Keys.cpp
@@ -188,7 +188,26 @@ eKf2XCA00T3odUfXmQZme8hG6z7GKVOdn/0oY+vaX38brlCpRXDTm1WldyddUpMz
 ftcs6dibdnbQtbX6o9E+KuvGHoNW5xcSjX8lwXTpopfvufPOLPcnFXi4UoYZ8NZ2
 2mRG78LkOA+SkOMutbt6w7TBDvADmFzuzvAULy4gsfcamOYcQ7uiHnnD+PoNiNbw
 flE/m/0zymX8I/Xu3+KKLhUnUROGC6zO3OnLHXCnEns=
------END CERTIFICATE-----)";
+-----END CERTIFICATE-----
+)";
+    std::string sample_cert_base64_der =
+        "MIIDHDCCAgSgAwIBAgIIGlbUz5cvweUwDQYJKoZIhvcNAQEFBQAwMTEvMC0GA1UE"
+        "AxMmc2VjdXJldG9rZW4uc3lzdGVtLmdzZXJ2aWNlYWNjb3VudC5jb20wHhcNMTkw"
+        "NDEwMjEyMDUxWhcNMTkwNDI3MDkzNTUxWjAxMS8wLQYDVQQDEyZzZWN1cmV0b2tl"
+        "bi5zeXN0ZW0uZ3NlcnZpY2VhY2NvdW50LmNvbTCCASIwDQYJKoZIhvcNAQEBBQAD"
+        "ggEPADCCAQoCggEBALRPFSsUi/bGcMVkD+XjJ6z/71u+7Wn1C1bRnM9sU3q7+Ere"
+        "DV6an+z+YsjblskBX73h1GyYvmtkyuL7Uq0N+y+RTOmd2fwDw48gM5FEq6DNpVVW"
+        "ZRIzzoMSLZCB+tg1eQZdGKtmctdd5Jjhwihf9Aa759fcj60GDG39G6A/w4Jok+J6"
+        "7sRabxxontJ4Kpo6zmwUKbWF8naJeCRTO0VAYLkJqEWO4VJTIHJeu2WpxM0qzvY9"
+        "IY5Yd7Njegu64FoHU55dSfee2KwDa0/bajrknJfxWBN4hk/rqgGjxQmzAYMCB7/p"
+        "/9Snfg4NmfX5cJJ01SNzY6Q/mJRjB3iX2PBz+GsCAwEAAaM4MDYwDAYDVR0TAQH/"
+        "BAIwADAOBgNVHQ8BAf8EBAMCB4AwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwIwDQYJ"
+        "KoZIhvcNAQEFBQADggEBAKCSq0D+NIAsGULZrhXouurxInxDyq03xLNcxvKDQchc"
+        "XfGA1r3eltmlyKQb5TmAsuKwS/LAQ5z8SlRTOmDGVEtDwnw3S83C4ufXbP0eMB6H"
+        "eKf2XCA00T3odUfXmQZme8hG6z7GKVOdn/0oY+vaX38brlCpRXDTm1WldyddUpMz"
+        "ftcs6dibdnbQtbX6o9E+KuvGHoNW5xcSjX8lwXTpopfvufPOLPcnFXi4UoYZ8NZ2"
+        "2mRG78LkOA+SkOMutbt6w7TBDvADmFzuzvAULy4gsfcamOYcQ7uiHnnD+PoNiNbw"
+        "flE/m/0zymX8I/Xu3+KKLhUnUROGC6zO3OnLHXCnEns=";
     std::string sample_cert_pubkey = R"(-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtE8VKxSL9sZwxWQP5eMn
 rP/vW77tafULVtGcz2xTerv4St4NXpqf7P5iyNuWyQFfveHUbJi+a2TK4vtSrQ37


### PR DESCRIPTION
This is particularly useful when dealing with JWKs x5c claim which is encoded as base64 DER. With this helper function the client can convert x5c claim to PEM, which makes it easy to interact with this library.