### PR TITLE
Relax operator access syntax for MSVC

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1800,7 +1800,8 @@ namespace jwt {
 
 		template<typename object_type, typename value_type, typename string_type>
 		using is_subcription_operator_signature =
-			typename std::is_same<decltype(std::declval<object_type>()[std::declval<const string_type>()]), value_type&>;
+			typename std::is_same<decltype(std::declval<object_type>()[std::declval<const string_type>()]),
+								  value_type&>;
 
 		template<typename object_type, typename value_type, typename string_type>
 		using is_at_const_signature =

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1800,8 +1800,7 @@ namespace jwt {
 
 		template<typename object_type, typename value_type, typename string_type>
 		using is_subcription_operator_signature =
-			typename std::is_same<decltype(std::declval<object_type>().operator[](std::declval<const string_type>())),
-								  value_type&>;
+			typename std::is_same<decltype(std::declval<object_type>()[std::declval<const string_type>()]), value_type&>;
 
 		template<typename object_type, typename value_type, typename string_type>
 		using is_at_const_signature =


### PR DESCRIPTION
Finally got to test master in a real code base... It does Client, Resource Server and Auth Server.

```txt
===============================================================================
All tests passed (15046 assertions in 37 test cases)

Tests completed in 2:41
```

:tada:

This was the only compiler error with Visual Studio 2017 and 2019.