### PR TITLE
Remove unused member from eddsa algorithm base

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1049,9 +1049,10 @@ namespace jwt {
 		/**
 		 * \brief Base class for EdDSA family of algorithms
 		 *
-		 * The EdDSA algorithms were introduced in [OpenSSL
-		 * v1.1.1](https://www.openssl.org/news/openssl-1.1.1-notes.html), so these algorithms are only available when
-		 * building against this version or higher.
+		 * https://tools.ietf.org/html/rfc8032
+		 *
+		 * The EdDSA algorithms were introduced in [OpenSSL v1.1.1](https://www.openssl.org/news/openssl-1.1.1-notes.html),
+		 * so these algorithms are only available when building against this version or higher.
 		 */
 		struct eddsa {
 			/**
@@ -1450,6 +1451,8 @@ namespace jwt {
 		/**
 		 * Ed25519 algorithm
 		 *
+		 * https://en.wikipedia.org/wiki/EdDSA#Ed25519
+		 *
 		 * Requires at least OpenSSL 1.1.1.
 		 */
 		struct ed25519 : public eddsa {
@@ -1470,6 +1473,8 @@ namespace jwt {
 		/**
 		 * Ed448 algorithm
 		 *
+		 * https://en.wikipedia.org/wiki/EdDSA#Ed448
+		 *
 		 * Requires at least OpenSSL 1.1.1.
 		 */
 		struct ed448 : public eddsa {
@@ -1484,7 +1489,7 @@ namespace jwt {
 			 */
 			explicit ed448(const std::string& public_key, const std::string& private_key = "",
 						   const std::string& public_key_password = "", const std::string& private_key_password = "")
-				: eddsa(public_key, private_key, public_key_password, private_key_password, "EdDSA") {}
+				: eddsa(public_key, private_key, public_key_password, private_key_password, EVP_shake256, "EdDSA") {}
 		};
 #endif
 

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1489,7 +1489,7 @@ namespace jwt {
 			 */
 			explicit ed448(const std::string& public_key, const std::string& private_key = "",
 						   const std::string& public_key_password = "", const std::string& private_key_password = "")
-				: eddsa(public_key, private_key, public_key_password, private_key_password, EVP_shake256, "EdDSA") {}
+				: eddsa(public_key, private_key, public_key_password, private_key_password, "EdDSA") {}
 		};
 #endif
 

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1062,12 +1062,11 @@ namespace jwt {
 			 * \param public_key_password Password to decrypt public key pem.
 			 * \param private_key_password Password
 			 * to decrypt private key pem.
-			 * \param md Pointer to hash function
 			 * \param name Name of the algorithm
 			 */
 			eddsa(const std::string& public_key, const std::string& private_key, const std::string& public_key_password,
-				  const std::string& private_key_password, const EVP_MD* (*md)(), std::string name)
-				: md(md), alg_name(std::move(name)) {
+				  const std::string& private_key_password, std::string name)
+				: alg_name(std::move(name)) {
 				if (!private_key.empty()) {
 					pkey = helper::load_private_key_from_string(private_key, private_key_password);
 				} else if (!public_key.empty()) {
@@ -1173,8 +1172,6 @@ namespace jwt {
 		private:
 			/// OpenSSL struct containing keys
 			std::shared_ptr<EVP_PKEY> pkey;
-			/// Hash generator
-			const EVP_MD* (*md)();
 			/// algorithm's name
 			const std::string alg_name;
 		};
@@ -1467,7 +1464,7 @@ namespace jwt {
 			 */
 			explicit ed25519(const std::string& public_key, const std::string& private_key = "",
 							 const std::string& public_key_password = "", const std::string& private_key_password = "")
-				: eddsa(public_key, private_key, public_key_password, private_key_password, EVP_sha512, "EdDSA") {}
+				: eddsa(public_key, private_key, public_key_password, private_key_password, "EdDSA") {}
 		};
 
 		/**
@@ -1487,7 +1484,7 @@ namespace jwt {
 			 */
 			explicit ed448(const std::string& public_key, const std::string& private_key = "",
 						   const std::string& public_key_password = "", const std::string& private_key_password = "")
-				: eddsa(public_key, private_key, public_key_password, private_key_password, EVP_sha256, "EdDSA") {}
+				: eddsa(public_key, private_key, public_key_password, private_key_password, "EdDSA") {}
 		};
 #endif
 


### PR DESCRIPTION
resolves #134

Minor API break but I doubt anyone is using the base class.

***

Additional Information ℹ️ 

- This matches the spec
  - https://tools.ietf.org/html/rfc8032#section-3.3
  - https://tools.ietf.org/html/rfc8032#section-4
- And OpenSSL docs
  -  https://www.openssl.org/docs/man1.1.1/man7/Ed25519.html
  - https://www.openssl.org/docs/man1.1.1/man7/Ed448.html