### PR TITLE
Rework verifier checks

### DIFF
--- a/tests/TokenTest.cpp
+++ b/tests/TokenTest.cpp
@@ -396,6 +396,10 @@ TEST(TokenTest, VerifyFail) {
 			ASSERT_THROW(verify.verify(decoded_token), jwt::token_verification_exception);
 		}
 		{
+			auto verify = jwt::verify().allow_algorithm(jwt::algorithm::none{}).with_type("JWT");
+			ASSERT_THROW(verify.verify(decoded_token), jwt::token_verification_exception);
+		}
+		{
 			auto verify = jwt::verify()
 							  .allow_algorithm(jwt::algorithm::none{})
 							  .with_issuer("auth0")
@@ -705,6 +709,20 @@ TEST(TokenTest, VerifyTokenIAT) {
 
 	auto verify = jwt::verify<test_clock, jwt::picojson_traits>({std::chrono::system_clock::from_time_t(110)})
 					  .allow_algorithm(jwt::algorithm::none{});
+	ASSERT_NO_THROW(verify.verify(decoded_token));
+	std::error_code ec;
+	ASSERT_NO_THROW(verify.verify(decoded_token, ec));
+	ASSERT_FALSE(!(!ec));
+	ASSERT_EQ(ec.value(), 0);
+}
+
+TEST(TokenTest, VerifyTokenType) {
+	auto token = jwt::create().set_type("JWS").sign(jwt::algorithm::none{});
+	auto decoded_token = jwt::decode(token);
+
+	auto verify = jwt::verify()
+					.with_type("jws")
+					.allow_algorithm(jwt::algorithm::none{});
 	ASSERT_NO_THROW(verify.verify(decoded_token));
 	std::error_code ec;
 	ASSERT_NO_THROW(verify.verify(decoded_token, ec));

--- a/tests/TokenTest.cpp
+++ b/tests/TokenTest.cpp
@@ -720,9 +720,7 @@ TEST(TokenTest, VerifyTokenType) {
 	auto token = jwt::create().set_type("JWS").sign(jwt::algorithm::none{});
 	auto decoded_token = jwt::decode(token);
 
-	auto verify = jwt::verify()
-					.with_type("jws")
-					.allow_algorithm(jwt::algorithm::none{});
+	auto verify = jwt::verify().with_type("jws").allow_algorithm(jwt::algorithm::none{});
 	ASSERT_NO_THROW(verify.verify(decoded_token));
 	std::error_code ec;
 	ASSERT_NO_THROW(verify.verify(decoded_token, ec));


### PR DESCRIPTION
Reworked the verifier core to allow more flexibility when checking.
This also removes the special cases for nbf, iat, exp and aud.

Basically I replaced the exact matching against a single value with a more flexible callback for each claim that gets passed some context and can return error codes in case they don't verify correctly. This allows for way more flexible checks like doing deep checks of objects or case insensitive checks.

This is not a final proposal, but more like a proof of the idea. I am absolutely open to improvements/changes even if they completely restructure this.