### PR TITLE
Fix tests for OpenSSL 3.0.0

### DIFF
--- a/.github/actions/install/openssl/action.yml
+++ b/.github/actions/install/openssl/action.yml
@@ -1,0 +1,19 @@
+name: Install OpenSSL
+description: Install and setup OpenSSL for linking and building test application
+inputs:
+  version:
+    description: The desired OpenSSL version to install
+    required: false
+    default: "3.0.0-beta2"
+runs:
+  using: composite
+  steps:
+    - run: |
+        cd /tmp
+        wget http://artfiles.org/openssl.org/source/openssl-${{ inputs.version }}.tar.gz
+        tar -zvxf /tmp/openssl-${{ inputs.version }}.tar.gz
+        cd openssl-${{ inputs.version }}
+        ./config --prefix=/tmp --libdir=lib
+        make -j $(nproc)
+        sudo make -j $(nproc) install_sw
+      shell: bash

--- a/.github/actions/install/openssl/action.yml
+++ b/.github/actions/install/openssl/action.yml
@@ -4,14 +4,14 @@ inputs:
   version:
     description: The desired OpenSSL version to install
     required: false
-    default: "3.0.0-beta2"
+    default: "openssl-3.0.0-beta2"
 runs:
   using: composite
   steps:
     - run: |
         cd /tmp
-        wget http://artfiles.org/openssl.org/source/openssl-${{ inputs.version }}.tar.gz
-        tar -zvxf /tmp/openssl-${{ inputs.version }}.tar.gz
+        wget https://github.com/openssl/openssl/archive/refs/tags/${{ inputs.version }}.tar.gz
+        tar -zxf /tmp/${{ inputs.version }}.tar.gz
         cd openssl-${{ inputs.version }}
         ./config --prefix=/tmp --libdir=lib
         make -j $(nproc)

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -10,7 +10,7 @@ on:
       - "include/jwt-cpp/**"
       - "tests/cmake/**"
       - ".github/actions/**"
-      - ".github/workflows/cmake.yml"
+      - ".github/workflows/openssl.yml"
 
 jobs:
   with-openssl:
@@ -34,4 +34,3 @@ jobs:
 
       - name: test
         run: ./tests/jwt-cpp-test
-

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        openssl: ["3.0.0-beta2", "1.1.1k"]
+        openssl: ["openssl-3.0.0-beta2", "OpenSSL_1_1_1k"]
     steps:
       - uses: actions/checkout@v2
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -1,0 +1,37 @@
+name: OpenSSL CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    paths:
+      - "CMakeLists.txt"
+      - "include/jwt-cpp/**"
+      - "tests/cmake/**"
+      - ".github/actions/**"
+      - ".github/workflows/cmake.yml"
+
+jobs:
+  with-openssl:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        openssl: ["3.0.0-beta2", "1.1.1k"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: lukka/get-cmake@latest
+      - uses: ./.github/actions/install/gtest
+      - uses: ./.github/actions/install/openssl
+        with:
+          version: ${{ matrix.openssl }}
+
+      - name: configure
+        run: |
+          cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp
+
+      - run: make
+
+      - name: test
+        run: ./tests/jwt-cpp-test
+

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -40,6 +40,10 @@
 #endif
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define OPENSSL3
+#endif
+
 // If openssl version less than 1.1
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define OPENSSL10

--- a/tests/OpenSSLErrorTest.cpp
+++ b/tests/OpenSSLErrorTest.cpp
@@ -73,8 +73,14 @@ EVP_PKEY* X509_get_pubkey(X509* x) {
 		return origMethod(x);
 }
 
-int PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x) {
-	static int (*origMethod)(BIO * bp, EVP_PKEY * x) = nullptr;
+#ifdef OPENSSL3
+#define OPENSSL_CONST const
+#else
+#define OPENSSL_CONST
+#endif
+
+int PEM_write_bio_PUBKEY(BIO* bp, OPENSSL_CONST EVP_PKEY* x) {
+	static int (*origMethod)(BIO * bp, OPENSSL_CONST EVP_PKEY * x) = nullptr;
 	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "PEM_write_bio_PUBKEY");
 	bool fail = fail_PEM_write_bio_PUBKEY & 1;
 	fail_PEM_write_bio_PUBKEY = fail_PEM_write_bio_PUBKEY >> 1;
@@ -84,8 +90,8 @@ int PEM_write_bio_PUBKEY(BIO* bp, EVP_PKEY* x) {
 		return origMethod(bp, x);
 }
 
-int PEM_write_bio_X509(BIO* bp, X509* x) {
-	static int (*origMethod)(BIO * bp, X509 * x) = nullptr;
+int PEM_write_bio_X509(BIO* bp, OPENSSL_CONST X509* x) {
+	static int (*origMethod)(BIO * bp, OPENSSL_CONST X509 * x) = nullptr;
 	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "PEM_write_bio_X509");
 	bool fail = fail_PEM_write_bio_cert & 1;
 	fail_PEM_write_bio_cert = fail_PEM_write_bio_cert >> 1;


### PR DESCRIPTION
OpenSSL 3.0.0 changes the signature of
`int PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x);` to
`int PEM_write_bio_PUBKEY(BIO *bp, const EVP_PKEY *x);`,

and 
`int PEM_write_bio_X509(BIO *bp, X509 *x);` to
`int PEM_write_bio_X509(BIO *bp, const X509 *x);`.

The following tests failed since simulation of OpenSSL errors did not take place:
- `OpenSSLErrorTest.ExtractPubkeyFromCert`
- `OpenSSLErrorTest.ConvertCertBase64DerToPem`
- `OpenSSLErrorTest.ConvertCertBase64DerToPemErrorCode`
- `OpenSSLErrorTest.ECDSACertificate`
- `OpenSSLErrorTest.EdDSACertificate`