### PR TITLE
📈 Improving OpenSSL test coverage

### DIFF
--- a/.github/workflows/libresssl.yml
+++ b/.github/workflows/libresssl.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        libressl: ["3.3.1", "3.2.3", "3.1.5"]
+        libressl: ["3.3.3", "3.2.5", "3.1.5"]
     steps:
       - uses: actions/checkout@v2
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        openssl: ["openssl-3.0.0-beta2", "OpenSSL_1_1_1k", "OpenSSL_1_1_0l", "OpenSSL_1_0_2u"]
+        openssl: ["openssl-3.0.0-beta2", "OpenSSL_1_1_1k", "OpenSSL_1_1_0i", "OpenSSL_1_0_2u"]
     steps:
       - uses: actions/checkout@v2
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -34,3 +34,30 @@ jobs:
 
       - name: test
         run: ./tests/jwt-cpp-test
+
+      - name: badge success
+        if: github.event_name == 'push' && success()
+        uses: ./.github/actions/badge
+        with:
+          category: openssl
+          label: ${{ matrix.openssl }}
+
+      - name: badge failure
+        if: github.event_name == 'push' && !success()
+        uses: ./.github/actions/badge
+        with:
+          category: openssl
+          label: ${{ matrix.openssl }}
+          message: Failing
+          color: red
+
+      - name: badge publish
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: badges
+          publish_dir: ./badges
+          keep_files: true
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        openssl: ["openssl-3.0.0-beta2", "OpenSSL_1_1_1k"]
+        openssl: ["openssl-3.0.0-beta2", "OpenSSL_1_1_1k", "OpenSSL_1_1_0l", "OpenSSL_1_0_2u"]
     steps:
       - uses: actions/checkout@v2
       - uses: lukka/get-cmake@latest

--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ In the name of flexibility and extensibility, jwt-cpp supports both [OpenSSL](ht
 
 | OpenSSL              | LibreSSL        |
 | -------------------- | --------------- |
-| [1.0.2][1.0.2]       | ![3.1.5][l3.1]  |
-| 1.1.0                | ![3.2.5][l3.2]  |
+| ![1.0.2u][o1.0.2]    | ![3.1.5][l3.1]  |
+| ![1.1.0i][o1.1.0]    | ![3.2.5][l3.2]  |
 | ![1.1.1k][o1.1.1]    | ![3.3.3][l3.3]  |
-| ![3.0.0-beta2][o3.0] | ![3.3.3][l3.3]  |
+| ![3.0.0-beta2][o3.0] |                 |
 
-[1.0.2]: https://travis-ci.com/github/Thalhammer/jwt-cpp
+[o1.0.2]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/OpenSSL_1_0_2u/shields.json
+[o1.1.0]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/OpenSSL_1_1_0i/shields.json
 [o1.1.1]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/OpenSSL_1_1_1k/shields.json
 [o3.0]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/openssl-3.0.0-beta2/shields.json
 [l3.1]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.1.5/shields.json

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ In the name of flexibility and extensibility, jwt-cpp supports both [OpenSSL](ht
 
 | OpenSSL        | LibreSSL        |
 | -------------- | --------------- |
-| [1.0.2][1.0.2] | ![3.1.5][3.1]   |
-| 1.1.0          | ![3.2.3][3.2]   |
-| [1.1.1][1.1.1] | ![3.3.1][3.3]   |
+| [1.0.2][1.0.2] | ![3.1.5][l3.1]  |
+| 1.1.0          | ![3.2.5][l3.2]  |
+| [1.1.1][1.1.1] | ![3.3.3][l3.3]  |
 
 [1.0.2]: https://travis-ci.com/github/Thalhammer/jwt-cpp
 [1.1.1]: https://github.com/Thalhammer/jwt-cpp/actions?query=workflow%3A%22Coverage+CI%22
-[3.1]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.1.5/shields.json
-[3.2]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.2.3/shields.json
-[3.3]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.3.1/shields.json
+[l3.1]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.1.5/shields.json
+[l3.2]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.2.5/shields.json
+[l3.3]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.3.3/shields.json
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ For completeness, here is a list of all supported algorithms:
 
 In the name of flexibility and extensibility, jwt-cpp supports both [OpenSSL](https://github.com/openssl/openssl) and [LibreSSL](https://github.com/libressl-portable/portable). These are the version which are, or have been, tested:
 
-| OpenSSL        | LibreSSL        |
-| -------------- | --------------- |
-| [1.0.2][1.0.2] | ![3.1.5][l3.1]  |
-| 1.1.0          | ![3.2.5][l3.2]  |
-| [1.1.1][1.1.1] | ![3.3.3][l3.3]  |
+| OpenSSL              | LibreSSL        |
+| -------------------- | --------------- |
+| [1.0.2][1.0.2]       | ![3.1.5][l3.1]  |
+| 1.1.0                | ![3.2.5][l3.2]  |
+| ![1.1.1k][o1.1.1]    | ![3.3.3][l3.3]  |
+| ![3.0.0-beta2][o3.0] | ![3.3.3][l3.3]  |
 
 [1.0.2]: https://travis-ci.com/github/Thalhammer/jwt-cpp
-[1.1.1]: https://github.com/Thalhammer/jwt-cpp/actions?query=workflow%3A%22Coverage+CI%22
+[o1.1.1]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/OpenSSL_1_1_1k/shields.json
+[o3.0]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/openssl-3.0.0-beta2/shields.json
 [l3.1]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.1.5/shields.json
 [l3.2]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.2.5/shields.json
 [l3.3]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.3.3/shields.json

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1052,6 +1052,7 @@ namespace jwt {
 		};
 
 #ifndef OPENSSL110
+#ifndef OPENSSL10
 		/**
 		 * \brief Base class for EdDSA family of algorithms
 		 *
@@ -1192,6 +1193,7 @@ namespace jwt {
 			/// algorithm's name
 			const std::string alg_name;
 		};
+#endif
 #endif
 		/**
 		 * \brief Base class for PSS-RSA family of algorithms

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -41,18 +41,18 @@
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L // 3.0.0
-#define OPENSSL3
+#define JWT_OPENSSL_3_0
 #elif OPENSSL_VERSION_NUMBER >= 0x10101000L // 1.1.1
-#define OPENSSL111
+#define JWT_OPENSSL_1_1_1
 #elif OPENSSL_VERSION_NUMBER >= 0x10100000L // 1.1.0
-#define OPENSSL110
-#elif OPENSSL_VERSION_NUMBER >= 0x10000000L // 1.0.2
-#define OPENSSL10
+#define JWT_OPENSSL_1_1_0
+#elif OPENSSL_VERSION_NUMBER >= 0x10000000L // 1.0.0
+#define JWT_OPENSSL_1_0_0
 #endif
 
 #if defined(LIBRESSL_VERSION_NUMBER)
-#define OPENSSL10
-#define OPENSSL110
+#define JWT_OPENSSL_1_0_0
+#define JWT_OPENSSL_1_1_0
 #endif
 
 #ifndef JWT_CLAIM_EXPLICIT
@@ -631,7 +631,7 @@ namespace jwt {
 		 * \return bignum as string
 		 */
 		inline
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 			static std::string
 			bn2raw(BIGNUM* bn)
 #else
@@ -789,7 +789,7 @@ namespace jwt {
 			 */
 			std::string sign(const std::string& data, std::error_code& ec) const {
 				ec.clear();
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_destroy);
 #else
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_free);
@@ -826,7 +826,7 @@ namespace jwt {
 			 */
 			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_destroy);
 #else
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_free);
@@ -940,7 +940,7 @@ namespace jwt {
 					ec = error::signature_generation_error::ecdsa_do_sign_failed;
 					return {};
 				}
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 
 				auto rr = helper::bn2raw(sig->r);
 				auto rs = helper::bn2raw(sig->s);
@@ -971,7 +971,7 @@ namespace jwt {
 				auto r = helper::raw2bn(signature.substr(0, signature.size() / 2));
 				auto s = helper::raw2bn(signature.substr(signature.size() / 2));
 
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 				ECDSA_SIG sig;
 				sig.r = r.get();
 				sig.s = s.get();
@@ -1010,7 +1010,7 @@ namespace jwt {
 			 * \return Hash of data
 			 */
 			std::string generate_hash(const std::string& data, std::error_code& ec) const {
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(),
 																			   &EVP_MD_CTX_destroy);
 #else
@@ -1051,8 +1051,7 @@ namespace jwt {
 			const size_t signature_length;
 		};
 
-#ifndef OPENSSL110
-#ifndef OPENSSL10
+#if !defined(JWT_OPENSSL_1_0_0) && !defined(JWT_OPENSSL_1_1_0)
 		/**
 		 * \brief Base class for EdDSA family of algorithms
 		 *
@@ -1090,7 +1089,7 @@ namespace jwt {
 			 */
 			std::string sign(const std::string& data, std::error_code& ec) const {
 				ec.clear();
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(),
 																			   &EVP_MD_CTX_destroy);
 #else
@@ -1143,7 +1142,7 @@ namespace jwt {
 			 */
 			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(),
 																			   &EVP_MD_CTX_destroy);
 #else
@@ -1193,7 +1192,6 @@ namespace jwt {
 			/// algorithm's name
 			const std::string alg_name;
 		};
-#endif
 #endif
 		/**
 		 * \brief Base class for PSS-RSA family of algorithms
@@ -1301,7 +1299,7 @@ namespace jwt {
 			 * \return Hash of data
 			 */
 			std::string generate_hash(const std::string& data, std::error_code& ec) const {
-#ifdef OPENSSL10
+#ifdef JWT_OPENSSL_1_0_0
 				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(),
 																			   &EVP_MD_CTX_destroy);
 #else
@@ -1465,7 +1463,7 @@ namespace jwt {
 				: ecdsa(public_key, private_key, public_key_password, private_key_password, EVP_sha512, "ES512", 132) {}
 		};
 
-#ifndef OPENSSL110
+#if !defined(JWT_OPENSSL_1_0_0) && !defined(JWT_OPENSSL_1_1_0)
 		/**
 		 * Ed25519 algorithm
 		 *

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -52,7 +52,6 @@
 
 #if defined(LIBRESSL_VERSION_NUMBER)
 #define JWT_OPENSSL_1_0_0
-#define JWT_OPENSSL_1_1_0
 #endif
 
 #ifndef JWT_CLAIM_EXPLICIT

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1089,7 +1089,12 @@ namespace jwt {
 			 */
 			std::string sign(const std::string& data, std::error_code& ec) const {
 				ec.clear();
-				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_free);
+#ifdef OPENSSL10
+				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(),
+																			   &EVP_MD_CTX_destroy);
+#else
+				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+#endif
 				if (!ctx) {
 					ec = error::signature_generation_error::create_context_failed;
 					return {};
@@ -1137,7 +1142,12 @@ namespace jwt {
 			 */
 			void verify(const std::string& data, const std::string& signature, std::error_code& ec) const {
 				ec.clear();
-				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_create(), EVP_MD_CTX_free);
+#ifdef OPENSSL10
+				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> ctx(EVP_MD_CTX_create(),
+																			   &EVP_MD_CTX_destroy);
+#else
+				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+#endif
 				if (!ctx) {
 					ec = error::signature_verification_error::create_context_failed;
 					return;

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -40,18 +40,14 @@
 #endif
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L // 3.0.0
 #define OPENSSL3
-#endif
-
-// If openssl version less than 1.1
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define OPENSSL10
-#endif
-
-// If openssl version less than 1.1.1
-#if OPENSSL_VERSION_NUMBER < 0x10101000L
+#elif OPENSSL_VERSION_NUMBER >= 0x10101000L // 1.1.1
+#define OPENSSL111
+#elif OPENSSL_VERSION_NUMBER >= 0x10100000L // 1.1.0
 #define OPENSSL110
+#elif OPENSSL_VERSION_NUMBER >= 0x10000000L // 1.0.2
+#define OPENSSL10
 #endif
 
 #if defined(LIBRESSL_VERSION_NUMBER)

--- a/tests/OpenSSLErrorTest.cpp
+++ b/tests/OpenSSLErrorTest.cpp
@@ -4,7 +4,7 @@
 
 #include <dlfcn.h>
 // TODO: Figure out why the tests fail on older openssl versions
-#ifndef OPENSSL110 // It fails on < 1.1 but no idea why.
+#ifndef OPENSSL10 // It fails on < 1.1 but no idea why.
 // LibreSSL has different return codes but was already outside of the effective scope
 
 /**

--- a/tests/OpenSSLErrorTest.cpp
+++ b/tests/OpenSSLErrorTest.cpp
@@ -4,7 +4,7 @@
 
 #include <dlfcn.h>
 // TODO: Figure out why the tests fail on older openssl versions
-#ifndef OPENSSL10 // It fails on < 1.1 but no idea why.
+#ifndef JWT_OPENSSL_1_0_0 // It fails on < 1.1 but no idea why.
 // LibreSSL has different return codes but was already outside of the effective scope
 
 /**
@@ -73,7 +73,7 @@ EVP_PKEY* X509_get_pubkey(X509* x) {
 		return origMethod(x);
 }
 
-#ifdef OPENSSL3
+#ifdef JWT_OPENSSL_3_0
 #define OPENSSL_CONST const
 #else
 #define OPENSSL_CONST
@@ -733,7 +733,7 @@ TEST(OpenSSLErrorTest, PS256VerifyErrorCode) {
 	run_multitest(mapping, [&alg, &signature](std::error_code& ec) { alg.verify("testdata", signature, ec); });
 }
 
-#ifndef OPENSSL110
+#if !defined(JWT_OPENSSL_1_0_0) && !defined(JWT_OPENSSL_1_1_0)
 TEST(OpenSSLErrorTest, EdDSAKey) {
 	std::vector<multitest_entry> mapping{
 		// load_private_key_from_string

--- a/tests/TokenTest.cpp
+++ b/tests/TokenTest.cpp
@@ -174,7 +174,7 @@ TEST(TokenTest, CreateTokenES512NoPrivate) {
 		jwt::signature_generation_exception);
 }
 
-#ifndef OPENSSL110
+#if !defined(JWT_OPENSSL_1_0_0) && !defined(JWT_OPENSSL_1_1_0)
 TEST(TokenTest, CreateTokenEd25519) {
 
 	auto token =
@@ -582,7 +582,7 @@ TEST(TokenTest, VerifyTokenPS256FailNoKey) {
 		jwt::rsa_exception);
 }
 
-#ifndef OPENSSL110
+#if !defined(JWT_OPENSSL_1_0_0) && !defined(JWT_OPENSSL_1_1_0)
 TEST(TokenTest, VerifyTokenEd25519) {
 	const std::string token =
 		"eyJhbGciOiJFZERTQSIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.OujgVcO8xQx5xLcAYWENCRU1SCGH5HcX4MX4o6wU3M4"


### PR DESCRIPTION
We previously had a link against Travis CI who's old runners had provided coverage of 1.0.2u... Since @kleinmrk was so kind to add an openssl test workflow. I re-enabled the tests here and added badges.

I also renames the macros so they are less likely to have conflicts + bump libressl test versions

Here's the state of the tests

| OpenSSL              | error test | eddsa |
| -------------------- | --------------- | ------- |
| 1.0.2u          |  ❌   | |
| [1.1.0i          | ✅     | | 
| 1.1.1k          | ✅    | ✅| 
| 3.0.0-beta2 |✅   | ✅|