### PR TITLE
Fix to_lower_unicode to do what it claims

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2797,7 +2797,7 @@ namespace jwt {
 				std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> conv;
 				auto wide = conv.from_bytes(str);
 				auto& f = std::use_facet<std::ctype<wchar_t>>(loc);
-				f.toupper(&wide[0], &wide[0] + wide.size());
+				f.tolower(&wide[0], &wide[0] + wide.size());
 				return conv.to_bytes(wide);
 			}
 		};


### PR DESCRIPTION
No idea how it came in there and it doesn't influence anything as long as both expected and checked
value have the same casing (which they do since we apply it to both).