### PR TITLE
simplify reading of EC keys

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -639,8 +639,8 @@ namespace jwt {
 		 * \param pw		Password used to decrypt certificate (leave empty if not encrypted)
 		 * \param ec		error_code for error_detection (gets cleared if no error occures)
 		 */
-		inline std::shared_ptr<EVP_PKEY> load_public_ec_key_from_string(const std::string& key,
-																	 const std::string& password, std::error_code& ec) {
+		inline std::shared_ptr<EVP_PKEY>
+		load_public_ec_key_from_string(const std::string& key, const std::string& password, std::error_code& ec) {
 			ec.clear();
 			std::unique_ptr<BIO, decltype(&BIO_free_all)> pubkey_bio(BIO_new(BIO_s_mem()), BIO_free_all);
 			if (!pubkey_bio) {
@@ -684,7 +684,7 @@ namespace jwt {
 		 * \throw			ecdsa_exception if an error occurred
 		 */
 		inline std::shared_ptr<EVP_PKEY> load_public_ec_key_from_string(const std::string& key,
-																	 const std::string& password = "") {
+																		const std::string& password = "") {
 			std::error_code ec;
 			auto res = load_public_ec_key_from_string(key, password, ec);
 			error::throw_if_error(ec);
@@ -728,7 +728,7 @@ namespace jwt {
 		 * \throw			ecdsa_exception if an error occurred
 		 */
 		inline std::shared_ptr<EVP_PKEY> load_private_ec_key_from_string(const std::string& key,
-																		const std::string& password = "") {
+																		 const std::string& password = "") {
 			std::error_code ec;
 			auto res = load_private_ec_key_from_string(key, password, ec);
 			error::throw_if_error(ec);

--- a/tests/OpenSSLErrorTest.cpp
+++ b/tests/OpenSSLErrorTest.cpp
@@ -343,8 +343,8 @@ int EVP_DigestVerify(EVP_MD_CTX* ctx, unsigned char* sigret, size_t* siglen, con
 		return origMethod(ctx, sigret, siglen, tbs, tbslen);
 }
 
-EC_KEY* EVP_PKEY_get1_EC_KEY(EVP_PKEY *pkey) {
-	static EC_KEY* (*origMethod)(EVP_PKEY *pkey) = nullptr;
+EC_KEY* EVP_PKEY_get1_EC_KEY(EVP_PKEY* pkey) {
+	static EC_KEY* (*origMethod)(EVP_PKEY * pkey) = nullptr;
 	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "EVP_PKEY_get1_EC_KEY");
 	bool fail = fail_EVP_PKEY_get1_EC_KEY & 1;
 	fail_EVP_PKEY_get1_EC_KEY = fail_EVP_PKEY_get1_EC_KEY >> 1;

--- a/tests/OpenSSLErrorTest.cpp
+++ b/tests/OpenSSLErrorTest.cpp
@@ -42,6 +42,7 @@ static uint64_t fail_EVP_DigestSignInit = 0;
 static uint64_t fail_EVP_DigestSign = 0;
 static uint64_t fail_EVP_DigestVerifyInit = 0;
 static uint64_t fail_EVP_DigestVerify = 0;
+static uint64_t fail_EVP_PKEY_get1_EC_KEY = 0;
 
 BIO* BIO_new(const BIO_METHOD* type) {
 	static BIO* (*origMethod)(const BIO_METHOD*) = nullptr;
@@ -342,6 +343,17 @@ int EVP_DigestVerify(EVP_MD_CTX* ctx, unsigned char* sigret, size_t* siglen, con
 		return origMethod(ctx, sigret, siglen, tbs, tbslen);
 }
 
+EC_KEY* EVP_PKEY_get1_EC_KEY(EVP_PKEY *pkey) {
+	static EC_KEY* (*origMethod)(EVP_PKEY *pkey) = nullptr;
+	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "EVP_PKEY_get1_EC_KEY");
+	bool fail = fail_EVP_PKEY_get1_EC_KEY & 1;
+	fail_EVP_PKEY_get1_EC_KEY = fail_EVP_PKEY_get1_EC_KEY >> 1;
+	if (fail)
+		return nullptr;
+	else
+		return origMethod(pkey);
+}
+
 /**
  * =========== End of black magic ============
  */
@@ -609,21 +621,35 @@ TEST(OpenSSLErrorTest, RS256VerifyErrorCode) {
 	run_multitest(mapping, [&alg, &signature](std::error_code& ec) { alg.verify("testdata", signature, ec); });
 }
 
-TEST(OpenSSLErrorTest, ECDSAKey) {
+TEST(OpenSSLErrorTest, LoadECDSAPrivateKeyFromString) {
 	std::vector<multitest_entry> mapping{
 		{&fail_BIO_new, 1, jwt::error::ecdsa_error::create_mem_bio_failed},
 		{&fail_BIO_write, 1, jwt::error::ecdsa_error::load_key_bio_write},
-		{&fail_PEM_read_bio_EC_PUBKEY, 1, jwt::error::ecdsa_error::load_key_bio_read},
-		// Privkey section
-		{&fail_BIO_new, 2, jwt::error::ecdsa_error::create_mem_bio_failed},
-		{&fail_BIO_write, 2, jwt::error::ecdsa_error::load_key_bio_write},
-		{&fail_PEM_read_bio_ECPrivateKey, 1, jwt::error::ecdsa_error::load_key_bio_read},
+		{&fail_PEM_read_bio_PrivateKey, 1, jwt::error::ecdsa_error::load_key_bio_read},
 		{&fail_EC_KEY_check_key, 1, jwt::error::ecdsa_error::invalid_key},
+		{&fail_EVP_PKEY_get1_EC_KEY, 1, jwt::error::ecdsa_error::invalid_key},
 	};
 
 	run_multitest(mapping, [](std::error_code& ec) {
 		try {
-			jwt::algorithm::es256 alg{ecdsa256_pub_key, ecdsa256_priv_key};
+			jwt::algorithm::es256 alg{"", ecdsa256_priv_key};
+			FAIL(); // Should never reach this
+		} catch (const std::system_error& e) { ec = e.code(); }
+	});
+}
+
+TEST(OpenSSLErrorTest, LoadECDSAPublicKeyFromString) {
+	std::vector<multitest_entry> mapping{
+		{&fail_BIO_new, 1, jwt::error::ecdsa_error::create_mem_bio_failed},
+		{&fail_BIO_write, 1, jwt::error::ecdsa_error::load_key_bio_write},
+		{&fail_PEM_read_bio_PUBKEY, 1, jwt::error::ecdsa_error::load_key_bio_read},
+		{&fail_EC_KEY_check_key, 1, jwt::error::ecdsa_error::invalid_key},
+		{&fail_EVP_PKEY_get1_EC_KEY, 1, jwt::error::ecdsa_error::invalid_key},
+	};
+
+	run_multitest(mapping, [](std::error_code& ec) {
+		try {
+			jwt::algorithm::es256 alg{ecdsa256_pub_key, ""};
 			FAIL(); // Should never reach this
 		} catch (const std::system_error& e) { ec = e.code(); }
 	});
@@ -632,7 +658,7 @@ TEST(OpenSSLErrorTest, ECDSAKey) {
 TEST(OpenSSLErrorTest, ECDSACertificate) {
 	std::vector<multitest_entry> mapping{{&fail_BIO_new, 1, jwt::error::ecdsa_error::create_mem_bio_failed},
 										 {&fail_BIO_write, 1, jwt::error::ecdsa_error::load_key_bio_write},
-										 {&fail_PEM_read_bio_EC_PUBKEY, 1, jwt::error::ecdsa_error::load_key_bio_read},
+										 {&fail_PEM_read_bio_PUBKEY, 1, jwt::error::ecdsa_error::load_key_bio_read},
 										 // extract_pubkey_from_cert
 										 {&fail_BIO_new, 2, jwt::error::rsa_error::create_mem_bio_failed},
 										 {&fail_PEM_read_bio_X509, 1, jwt::error::rsa_error::cert_load_failed},

--- a/tests/TokenTest.cpp
+++ b/tests/TokenTest.cpp
@@ -748,8 +748,6 @@ TEST(TokenTest, ThrowInvalidKeyLength) {
 	// But also if only one cert has the wrong size
 	ASSERT_THROW(jwt::algorithm::es256(ecdsa256_pub_key, ecdsa384_priv_key), jwt::ecdsa_exception);
 	ASSERT_THROW(jwt::algorithm::es256(ecdsa256_pub_key, ecdsa521_priv_key), jwt::ecdsa_exception);
-	ASSERT_THROW(jwt::algorithm::es256(ecdsa384_pub_key, ecdsa256_priv_key), jwt::ecdsa_exception);
-	ASSERT_THROW(jwt::algorithm::es256(ecdsa521_pub_key, ecdsa256_priv_key), jwt::ecdsa_exception);
 
 	ASSERT_THROW(jwt::algorithm::es384(ecdsa256_pub_key, ""), jwt::ecdsa_exception);
 	ASSERT_THROW(jwt::algorithm::es384("", ecdsa256_priv_key), jwt::ecdsa_exception);
@@ -760,8 +758,6 @@ TEST(TokenTest, ThrowInvalidKeyLength) {
 
 	ASSERT_THROW(jwt::algorithm::es384(ecdsa384_pub_key, ecdsa256_priv_key), jwt::ecdsa_exception);
 	ASSERT_THROW(jwt::algorithm::es384(ecdsa384_pub_key, ecdsa521_priv_key), jwt::ecdsa_exception);
-	ASSERT_THROW(jwt::algorithm::es384(ecdsa256_pub_key, ecdsa384_priv_key), jwt::ecdsa_exception);
-	ASSERT_THROW(jwt::algorithm::es384(ecdsa521_pub_key, ecdsa384_priv_key), jwt::ecdsa_exception);
 
 	ASSERT_THROW(jwt::algorithm::es512(ecdsa256_pub_key, ""), jwt::ecdsa_exception);
 	ASSERT_THROW(jwt::algorithm::es512("", ecdsa256_priv_key), jwt::ecdsa_exception);
@@ -772,8 +768,6 @@ TEST(TokenTest, ThrowInvalidKeyLength) {
 
 	ASSERT_THROW(jwt::algorithm::es512(ecdsa521_pub_key, ecdsa256_priv_key), jwt::ecdsa_exception);
 	ASSERT_THROW(jwt::algorithm::es512(ecdsa521_pub_key, ecdsa384_priv_key), jwt::ecdsa_exception);
-	ASSERT_THROW(jwt::algorithm::es512(ecdsa256_pub_key, ecdsa521_priv_key), jwt::ecdsa_exception);
-	ASSERT_THROW(jwt::algorithm::es512(ecdsa384_pub_key, ecdsa521_priv_key), jwt::ecdsa_exception);
 
 	// Make sure we do not throw if the correct params are passed
 	ASSERT_NO_THROW(jwt::algorithm::es256(ecdsa256_pub_key, ecdsa256_priv_key));


### PR DESCRIPTION
This MR slightly changes how EC keys are read.

Currently, both private and public keys are read (if provided), but the public key has no effect and the internally used openssl structure is overridden by the private part. Thus the public key has no effecton the final ecdsa object other than possibly throwing exceptions in the constructor.

This MR reads the keys the same way as they are read for RSA key, i.e., prefer private key if present, and completely ignore public part.

I also switched from `PEM_read_bio_EC_PUBKEY` to `PEM_read_bio_PUBKEY`, and from `PEM_read_bio_ECPrivateKey` to `PEM_read_bio_PrivateKey`. This change made it obvious that one could use the same code for reading RSA and EC keys. The functions only differ in type of errors they report, e.g., `error::ecdsa_error::create_mem_bio_failed` vs. `error::rsa_error::create_mem_bio_failed`.