### PR TITLE
Replace RSA related deprecated functions

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -236,7 +236,8 @@ namespace jwt {
 			digestfinal_failed,
 			rsa_padding_failed,
 			rsa_private_encrypt_failed,
-			get_key_failed
+			get_key_failed,
+			set_rsa_pss_saltlen_failed,
 		};
 		/**
 		 * \brief Error category for signature generation errors
@@ -265,11 +266,13 @@ namespace jwt {
 					case signature_generation_error::digestfinal_failed:
 						return "failed to create signature: DigestFinal failed";
 					case signature_generation_error::rsa_padding_failed:
-						return "failed to create signature: RSA_padding_add_PKCS1_PSS failed";
+						return "failed to create signature: EVP_PKEY_CTX_set_rsa_padding failed";
 					case signature_generation_error::rsa_private_encrypt_failed:
 						return "failed to create signature: RSA_private_encrypt failed";
 					case signature_generation_error::get_key_failed:
 						return "failed to generate signature: Could not get key";
+					case signature_generation_error::set_rsa_pss_saltlen_failed:
+						return "failed to create signature: EVP_PKEY_CTX_set_rsa_pss_saltlen failed";
 					default: return "unknown signature generation error";
 					}
 				}
@@ -1308,31 +1311,48 @@ namespace jwt {
 			 */
 			std::string sign(const std::string& data, std::error_code& ec) const {
 				ec.clear();
-				auto hash = this->generate_hash(data, ec);
-				if (ec) return {};
-
-				std::unique_ptr<RSA, decltype(&RSA_free)> key(EVP_PKEY_get1_RSA(pkey.get()), RSA_free);
-				if (!key) {
-					ec = error::signature_generation_error::get_key_failed;
+#ifdef JWT_OPENSSL_1_0_0
+				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)> md_ctx(EVP_MD_CTX_create(),
+																				  &EVP_MD_CTX_destroy);
+#else
+				std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> md_ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+#endif
+				if (!md_ctx) {
+					ec = error::signature_generation_error::create_context_failed;
 					return {};
 				}
-				const int size = EVP_PKEY_size(pkey.get());
-
-				std::string padded(size, 0x00);
-				if (RSA_padding_add_PKCS1_PSS(key.get(), (unsigned char*)padded.data(),
-											  reinterpret_cast<const unsigned char*>(hash.data()), md(),
-											  -1) == 0) { // NOLINT(google-readability-casting) requires `const_cast`
+				EVP_PKEY_CTX* ctx = nullptr;
+				if (EVP_DigestSignInit(md_ctx.get(), &ctx, md(), nullptr, pkey.get()) != 1) {
+					ec = error::signature_generation_error::signinit_failed;
+					return {};
+				}
+				if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_PSS_PADDING) <= 0) {
 					ec = error::signature_generation_error::rsa_padding_failed;
 					return {};
 				}
-
-				std::string res(size, 0x00);
-				if (RSA_private_encrypt(size, reinterpret_cast<const unsigned char*>(padded.data()),
-										(unsigned char*)res.data(), key.get(), RSA_NO_PADDING) <
-					0) { // NOLINT(google-readability-casting) requires `const_cast`
-					ec = error::signature_generation_error::rsa_private_encrypt_failed;
+// wolfSSL does not require EVP_PKEY_CTX_set_rsa_pss_saltlen. The default behavior
+// sets the salt length to the hash length. Unlike OpenSSL which exposes this functionality.
+#ifndef LIBWOLFSSL_VERSION_HEX
+				if (EVP_PKEY_CTX_set_rsa_pss_saltlen(ctx, -1) <= 0) {
+					ec = error::signature_generation_error::set_rsa_pss_saltlen_failed;
 					return {};
 				}
+#endif
+				if (EVP_DigestUpdate(md_ctx.get(), data.data(), data.size()) != 1) {
+					ec = error::signature_generation_error::digestupdate_failed;
+					return {};
+				}
+
+				size_t size = EVP_PKEY_size(pkey.get());
+				std::string res(size, 0x00);
+				if (EVP_DigestSignFinal(
+						md_ctx.get(),
+						(unsigned char*)res.data(), // NOLINT(google-readability-casting) requires `const_cast`
+						&size) <= 0) {
+					ec = error::signature_generation_error::signfinal_failed;
+					return {};
+				}
+
 				return res;
 			}
 

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1316,7 +1316,7 @@ namespace jwt {
 					ec = error::signature_generation_error::get_key_failed;
 					return {};
 				}
-				const int size = RSA_size(key.get());
+				const int size = EVP_PKEY_size(pkey.get());
 
 				std::string padded(size, 0x00);
 				if (RSA_padding_add_PKCS1_PSS(key.get(), (unsigned char*)padded.data(),
@@ -1352,7 +1352,7 @@ namespace jwt {
 					ec = error::signature_verification_error::get_key_failed;
 					return;
 				}
-				const int size = RSA_size(key.get());
+				const int size = EVP_PKEY_size(pkey.get());
 
 				std::string sig(size, 0x00);
 				if (RSA_public_decrypt(

--- a/tests/HelperTest.cpp
+++ b/tests/HelperTest.cpp
@@ -59,7 +59,7 @@ TEST(HelperTest, ErrorCodeMessages) {
 	ASSERT_EQ(std::error_code(static_cast<jwt::error::ecdsa_error>(i)).message(),
 			  std::error_code(static_cast<jwt::error::ecdsa_error>(-1)).message());
 
-	for (i = 10; i < 16; i++) {
+	for (i = 10; i < 17; i++) {
 		ASSERT_NE(std::error_code(static_cast<jwt::error::signature_verification_error>(i)).message(),
 				  std::error_code(static_cast<jwt::error::signature_verification_error>(-1)).message());
 	}

--- a/tests/HelperTest.cpp
+++ b/tests/HelperTest.cpp
@@ -66,7 +66,7 @@ TEST(HelperTest, ErrorCodeMessages) {
 	ASSERT_EQ(std::error_code(static_cast<jwt::error::signature_verification_error>(i)).message(),
 			  std::error_code(static_cast<jwt::error::signature_verification_error>(-1)).message());
 
-	for (i = 10; i < 22; i++) {
+	for (i = 10; i < 23; i++) {
 		ASSERT_NE(std::error_code(static_cast<jwt::error::signature_generation_error>(i)).message(),
 				  std::error_code(static_cast<jwt::error::signature_generation_error>(-1)).message());
 	}


### PR DESCRIPTION
This MR replaces RSA related functions that are deprecated in OpenSSL 3.0.0 by non-deprecated alternatives.

Heads-up: The changes include adding values to `signature_verification_error` and `signature_generation_error` enums. This is a breaking change for code that does not use exceptions but error codes.