### PR TITLE
Replace deprecated functions

### DIFF
--- a/.github/workflows/ssl.yml
+++ b/.github/workflows/ssl.yml
@@ -59,7 +59,7 @@ jobs:
           version: "openssl-3.0.0"
 
       - name: configure
-        run: cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS="OPENSSL_NO_DEPRECATED_3_0=1" -DCMAKE_C_FLAGS="OPENSSL_NO_DEPRECATED_3_0=1"
+        run: cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS="-DOPENSSL_NO_DEPRECATED_3_0=1" -DCMAKE_C_FLAGS="-DOPENSSL_NO_DEPRECATED_3_0=1"
       - run: make
 
   libressl:

--- a/.github/workflows/ssl.yml
+++ b/.github/workflows/ssl.yml
@@ -47,6 +47,21 @@ jobs:
           label: ${{ matrix.openssl.name }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+  openssl-no-deprecated:
+    runs-on: ubuntu-latest
+    name: OpenSSL 3.0 No Deprecated
+    steps:
+      - uses: actions/checkout@v2
+      - uses: lukka/get-cmake@latest
+      - uses: ./.github/actions/install/gtest
+      - uses: ./.github/actions/install/openssl
+        with:
+          version: "openssl-3.0.0"
+
+      - name: configure
+        run: cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS=OPENSSL_NO_DEPRECATED_3_0 -DCMAKE_C_FLAGS=OPENSSL_NO_DEPRECATED_3_0
+      - run: make
+
   libressl:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ssl.yml
+++ b/.github/workflows/ssl.yml
@@ -59,7 +59,7 @@ jobs:
           version: "openssl-3.0.0"
 
       - name: configure
-        run: cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS=OPENSSL_NO_DEPRECATED_3_0 -DCMAKE_C_FLAGS=OPENSSL_NO_DEPRECATED_3_0
+        run: cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS="OPENSSL_NO_DEPRECATED_3_0=1" -DCMAKE_C_FLAGS="OPENSSL_NO_DEPRECATED_3_0=1"
       - run: make
 
   libressl:

--- a/tests/HelperTest.cpp
+++ b/tests/HelperTest.cpp
@@ -59,14 +59,14 @@ TEST(HelperTest, ErrorCodeMessages) {
 	ASSERT_EQ(std::error_code(static_cast<jwt::error::ecdsa_error>(i)).message(),
 			  std::error_code(static_cast<jwt::error::ecdsa_error>(-1)).message());
 
-	for (i = 10; i < 17; i++) {
+	for (i = 10; i < 18; i++) {
 		ASSERT_NE(std::error_code(static_cast<jwt::error::signature_verification_error>(i)).message(),
 				  std::error_code(static_cast<jwt::error::signature_verification_error>(-1)).message());
 	}
 	ASSERT_EQ(std::error_code(static_cast<jwt::error::signature_verification_error>(i)).message(),
 			  std::error_code(static_cast<jwt::error::signature_verification_error>(-1)).message());
 
-	for (i = 10; i < 23; i++) {
+	for (i = 10; i < 24; i++) {
 		ASSERT_NE(std::error_code(static_cast<jwt::error::signature_generation_error>(i)).message(),
 				  std::error_code(static_cast<jwt::error::signature_generation_error>(-1)).message());
 	}

--- a/tests/HelperTest.cpp
+++ b/tests/HelperTest.cpp
@@ -52,7 +52,7 @@ TEST(HelperTest, ErrorCodeMessages) {
 	ASSERT_EQ(std::error_code(static_cast<jwt::error::rsa_error>(i)).message(),
 			  std::error_code(static_cast<jwt::error::rsa_error>(-1)).message());
 
-	for (i = 10; i < 16; i++) {
+	for (i = 10; i < 17; i++) {
 		ASSERT_NE(std::error_code(static_cast<jwt::error::ecdsa_error>(i)).message(),
 				  std::error_code(static_cast<jwt::error::ecdsa_error>(-1)).message());
 	}


### PR DESCRIPTION
Addresses #150 

I tried my best to not introduce any new `#ifdefs` but I did not find any common non-deprecated interface for validating ECDSA [public](https://github.com/Thalhammer/jwt-cpp/compare/master...kleinmrk:replace-deprecated-functions#diff-be2369ece29c0945fc04ffe13a39767b7841fc2fabd3df209a26b3bb381a2fb2R1110) and [private](https://github.com/Thalhammer/jwt-cpp/compare/master...kleinmrk:replace-deprecated-functions#diff-be2369ece29c0945fc04ffe13a39767b7841fc2fabd3df209a26b3bb381a2fb2R1123) keys. These also propagated to [OpenSSLErrorTest.cpp](https://github.com/Thalhammer/jwt-cpp/compare/master...kleinmrk:replace-deprecated-functions#diff-a2e0d0b09d1f2a63dfbb21f283ecdeaab48c4fad8a0fda9f6040b15860cd96ceR719).