### PR TITLE
With hunter use relative CMake install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,10 @@ if(JWT_EXTERNAL_PICOJSON)
   target_link_libraries(jwt-cpp INTERFACE picojson::picojson>)
 endif()
 
-if(NOT JWT_CMAKE_FILES_INSTALL_DIR)
+# If Hunter is enabled, we need to explicit set relative paths so the files are palced correctly
+if(HUNTER_ENABLED)
+  set(JWT_CMAKE_FILES_INSTALL_DIR cmake)
+elseif(NOT JWT_CMAKE_FILES_INSTALL_DIR)
   set(JWT_CMAKE_FILES_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/cmake)
 endif()
 


### PR DESCRIPTION
This is just https://github.com/Thalhammer/jwt-cpp/commit/85fa9d1d6979952ccbad7ac9f97e088b02098862

but hopefully it does not break the other local CMake installation people are using

closes #175 