### PR TITLE
Fix Conan Example

### DIFF
--- a/example/conan/conanfile.txt
+++ b/example/conan/conanfile.txt
@@ -1,5 +1,6 @@
 [requires]
-jwt-cpp/0.4.0
+jwt-cpp/0.6.0
+picojson/1.3.0
 
 [generators]
 cmake

--- a/example/conan/conanfile.txt
+++ b/example/conan/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 jwt-cpp/0.6.0
-picojson/1.3.0
+picojson/cci.20210117
 
 [generators]
 cmake


### PR DESCRIPTION
As mentioned in a related issue, the Conan example is broken. It uses version `0.4.0` that still installs `picojson/1.3.0` as a dependency.

[For code versions greater than `0.5.0`](https://github.com/conan-io/conan-center-index/blob/master/recipes/jwt-cpp/all/conanfile.py#L29), `picojson` is no longer installed as a dependency, and the provided example fails to build.

In this PR I provide a minimal fix, but you may prefer to change the Conan recipe altogether.