### PR TITLE
Make jwt::decoded_jwt moveable

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2530,7 +2530,7 @@ namespace jwt {
 	class decoded_jwt : public header<json_traits>, public payload<json_traits> {
 	protected:
 		/// Unmodifed token, as passed to constructor
-		const typename json_traits::string_type token;
+		typename json_traits::string_type token;
 		/// Header part decoded from base64
 		typename json_traits::string_type header;
 		/// Unmodified header part in base64

--- a/tests/TokenTest.cpp
+++ b/tests/TokenTest.cpp
@@ -774,3 +774,29 @@ TEST(TokenTest, ThrowInvalidKeyLength) {
 	ASSERT_NO_THROW(jwt::algorithm::es384(ecdsa384_pub_key, ecdsa384_priv_key));
 	ASSERT_NO_THROW(jwt::algorithm::es512(ecdsa521_pub_key, ecdsa521_priv_key));
 }
+
+TEST(TokenTest, MoveDecodedToken) {
+	std::string token0 = "eyJhbGciOiJub25lIiwidHlwIjoiSldTIn0.eyJpc3MiOiJhdXRoMCJ9.";
+	std::string token1 =
+		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
+	auto decoded_token0 = jwt::decode(token0);
+	auto decoded_token1 = jwt::decode(token1);
+	decoded_token0 = std::move(decoded_token1);
+	ASSERT_EQ(token1, decoded_token0.get_token());
+
+	ASSERT_TRUE(decoded_token0.has_algorithm());
+	ASSERT_TRUE(decoded_token0.has_type());
+	ASSERT_FALSE(decoded_token0.has_content_type());
+	ASSERT_FALSE(decoded_token0.has_key_id());
+	ASSERT_TRUE(decoded_token0.has_issuer());
+	ASSERT_FALSE(decoded_token0.has_subject());
+	ASSERT_FALSE(decoded_token0.has_audience());
+	ASSERT_FALSE(decoded_token0.has_expires_at());
+	ASSERT_FALSE(decoded_token0.has_not_before());
+	ASSERT_FALSE(decoded_token0.has_issued_at());
+	ASSERT_FALSE(decoded_token0.has_id());
+
+	ASSERT_EQ("HS256", decoded_token0.get_algorithm());
+	ASSERT_EQ("JWS", decoded_token0.get_type());
+	ASSERT_EQ("auth0", decoded_token0.get_issuer());
+}


### PR DESCRIPTION
This removes the const specifier from the token member class so that objects of type jwt::decoded_token can be moved. IMO it is safe to do so as the variable is only exposed via `get_token` which returns a const reference to it.

I'm unsure though in regards to whether or not to make it private. Currently is protected, making it private would then make it a breaking change. 

This resolves #224  then.