### PR TITLE
Fix build with OPENSSL_NO_DEPRECATED

### DIFF
--- a/.github/workflows/ssl.yml
+++ b/.github/workflows/ssl.yml
@@ -50,7 +50,7 @@ jobs:
           version: "openssl-3.0.1"
 
       - name: configure
-        run: cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS="-DOPENSSL_NO_DEPRECATED_3_0=1" -DCMAKE_C_FLAGS="-DOPENSSL_NO_DEPRECATED_3_0=1"
+        run: cmake . -DJWT_BUILD_TESTS=ON -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS="-DOPENSSL_NO_DEPRECATED=1" -DCMAKE_C_FLAGS="-DOPENSSL_NO_DEPRECATED=1"
       - run: make
 
   libressl:

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -18,6 +18,7 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/pem.h>
+#include <openssl/rsa.h>
 #include <openssl/ssl.h>
 
 #include <algorithm>

--- a/tests/OpenSSLErrorTest.cpp
+++ b/tests/OpenSSLErrorTest.cpp
@@ -25,8 +25,6 @@ static uint64_t fail_BIO_ctrl = 0;
 static uint64_t fail_BIO_write = 0;
 static uint64_t fail_PEM_read_bio_PUBKEY = 0;
 static uint64_t fail_PEM_read_bio_PrivateKey = 0;
-static uint64_t fail_PEM_read_bio_EC_PUBKEY = 0;
-static uint64_t fail_PEM_read_bio_ECPrivateKey = 0;
 static uint64_t fail_HMAC = 0;
 static uint64_t fail_EVP_MD_CTX_new = 0;
 static uint64_t fail_EVP_DigestInit = 0;
@@ -43,7 +41,6 @@ static uint64_t fail_EC_KEY_check_key = 0;
 static uint64_t fail_EVP_PKEY_get1_EC_KEY = 0;
 #endif
 static uint64_t fail_ECDSA_SIG_new = 0;
-static uint64_t fail_ECDSA_do_sign = 0;
 static uint64_t fail_EVP_PKEY_get1_RSA = 0;
 static uint64_t fail_EVP_DigestSignInit = 0;
 static uint64_t fail_EVP_DigestSign = 0;
@@ -153,28 +150,6 @@ EVP_PKEY* PEM_read_bio_PrivateKey(BIO* bp, EVP_PKEY** x, pem_password_cb* cb, vo
 	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "PEM_read_bio_PrivateKey");
 	bool fail = fail_PEM_read_bio_PrivateKey & 1;
 	fail_PEM_read_bio_PrivateKey = fail_PEM_read_bio_PrivateKey >> 1;
-	if (fail)
-		return nullptr;
-	else
-		return origMethod(bp, x, cb, u);
-}
-
-EC_KEY* PEM_read_bio_EC_PUBKEY(BIO* bp, EC_KEY** x, pem_password_cb* cb, void* u) {
-	static EC_KEY* (*origMethod)(BIO * bp, EC_KEY * *x, pem_password_cb * cb, void* u) = nullptr;
-	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "PEM_read_bio_EC_PUBKEY");
-	bool fail = fail_PEM_read_bio_EC_PUBKEY & 1;
-	fail_PEM_read_bio_EC_PUBKEY = fail_PEM_read_bio_EC_PUBKEY >> 1;
-	if (fail)
-		return nullptr;
-	else
-		return origMethod(bp, x, cb, u);
-}
-
-EC_KEY* PEM_read_bio_ECPrivateKey(BIO* bp, EC_KEY** x, pem_password_cb* cb, void* u) {
-	static EC_KEY* (*origMethod)(BIO * bp, EC_KEY * *x, pem_password_cb * cb, void* u) = nullptr;
-	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "PEM_read_bio_ECPrivateKey");
-	bool fail = fail_PEM_read_bio_ECPrivateKey & 1;
-	fail_PEM_read_bio_ECPrivateKey = fail_PEM_read_bio_ECPrivateKey >> 1;
 	if (fail)
 		return nullptr;
 	else
@@ -339,17 +314,6 @@ ECDSA_SIG* ECDSA_SIG_new(void) {
 		return nullptr;
 	else
 		return origMethod();
-}
-
-ECDSA_SIG* ECDSA_do_sign(const unsigned char* dgst, int dgst_len, EC_KEY* eckey) {
-	static ECDSA_SIG* (*origMethod)(const unsigned char* dgst, int dgst_len, EC_KEY* eckey) = nullptr;
-	if (origMethod == nullptr) origMethod = (decltype(origMethod))dlsym(RTLD_NEXT, "ECDSA_do_sign");
-	bool fail = fail_ECDSA_do_sign & 1;
-	fail_ECDSA_do_sign = fail_ECDSA_do_sign >> 1;
-	if (fail)
-		return nullptr;
-	else
-		return origMethod(dgst, dgst_len, eckey);
 }
 
 struct rsa_st* EVP_PKEY_get1_RSA(EVP_PKEY* pkey) {


### PR DESCRIPTION
Add missing include to fix build with `OPENSSL_NO_DEPRECATED` defined and adjust the deprecation test to set this define. Also remove some unused re-definitions of OpenSSL functions in `OpenSSLErrorTest.cpp` that use types that are not defined with `OPENSSL_NO_DEPRECATED`.

Fixes #223.