### PR TITLE
Note why `as_object()` is missing in FAQ

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -6,7 +6,7 @@
 
 This is the expected behaviour. While the integrity of tokens is ensured by the generated/verified hash,
 the contents of the token are only **encoded and not encrypted**. This means you can be sure the token
-has not been modified by an unauthorized party, but you should not store confidential information in it. 
+has not been modified by an unauthorized party, but you should not store confidential information in it.
 Anyone with access to the token can read all the claims you put into it. They can however not modify
 them unless they have the (private or symetric) key used to generate the token. If you need to put
 confidential information into it, current industry recommends generating a random id and store the data on your

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -37,6 +37,16 @@ auto token = jwt::create()
 The signature includes both the header and payload, according to the RFCs... changing the payload would cause a discrepancy.
 That should result in the token being rejected. For more details checkout [#194](https://github.com/Thalhammer/jwt-cpp/issues/194).
 
+### Why does `jwt::basic_claim` have no `as_object()` method?
+
+This was brought up in [#212](https://github.com/Thalhammer/jwt-cpp/issues/212#issuecomment-1054344192) and
+[#101](https://github.com/Thalhammer/jwt-cpp/issues/101) as it's an excellent question.
+
+It simply was not required to handle the required keys in JWTs for signing or verification. All the the mandatory keys are numeric,
+string or arrary types which required type definitions and access.
+
+The alternative is to use the `to_json()` method and use the libraries own APIs to pick the data type you need.
+
 ## Build Issues
 
 ### Missing \_HMAC and \_EVP_sha256 symbols on Mac


### PR DESCRIPTION
Follow up from #212 