### PR TITLE
Allow to retrieve list of claims

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -3502,6 +3502,14 @@ namespace jwt {
 		}
 
 		bool empty() const noexcept { return jwk_claims.empty(); }
+
+		/**
+		 * Get all jwk claims
+		 * \return Map of claims
+		 */
+		std::unordered_map<typename json_traits::string_type, basic_claim_t> get_claims() const {
+			return this->jwk_claims.get_claims();
+		}
 	};
 
 	/**


### PR DESCRIPTION
Currently, it is not possible to iterate over the list of claims of a JWK. With this commit, the JWK gains a new method that exposes the underlying claims so that the callee can do some processing with it. This might be useful, if someone wants to copy all claims to a new object.