### PR TITLE
Fix as_date()'s std::bad_cast with decimal value

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <codecvt>
 #include <functional>
 #include <iterator>
@@ -2260,7 +2261,12 @@ namespace jwt {
 		 * \return content as date
 		 * \throw std::bad_cast Content was not a date
 		 */
-		date as_date() const { return std::chrono::system_clock::from_time_t(get_type() == json::type::number ? std::round(as_number()) : as_int()); }
+		date as_date() const {
+			using std::chrono::system_clock;
+			if (get_type() == json::type::number)
+				return system_clock::from_time_t(std::round(as_number()));
+			return system_clock::from_time_t(as_int());
+		}
 
 		/**
 		 * Get the contained JSON value as an array

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2252,7 +2252,7 @@ namespace jwt {
 		 */
 		typename json_traits::string_type as_string() const { return json_traits::as_string(val); }
 
-	    /**
+		/**
 		 * \brief Get the contained JSON value as a date
 		 *
 		 * If the value is a decimal, it is rounded up to the closest integer

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2252,12 +2252,26 @@ namespace jwt {
 		 */
 		typename json_traits::string_type as_string() const { return json_traits::as_string(val); }
 
-		/**
-		 * Get the contained JSON value as a date
+	    /**
+		 * \brief Get the contained JSON value as a date
+		 *
+		 * If the value is a decimal, it is rounded up to the closest integer
+		 *
 		 * \return content as date
 		 * \throw std::bad_cast Content was not a date
 		 */
-		date as_date() const { return std::chrono::system_clock::from_time_t(as_int()); }
+		date as_date() const {
+			std::time_t timestamp;
+			if (get_type() == json::type::number)
+			{
+				timestamp = std::round(as_number());
+			}
+			else
+			{
+				timestamp = as_int();
+			}
+			return std::chrono::system_clock::from_time_t(timestamp);
+		}
 
 		/**
 		 * Get the contained JSON value as an array

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2263,8 +2263,7 @@ namespace jwt {
 		 */
 		date as_date() const {
 			using std::chrono::system_clock;
-			if (get_type() == json::type::number)
-				return system_clock::from_time_t(std::round(as_number()));
+			if (get_type() == json::type::number) return system_clock::from_time_t(std::round(as_number()));
 			return system_clock::from_time_t(as_int());
 		}
 

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2260,18 +2260,7 @@ namespace jwt {
 		 * \return content as date
 		 * \throw std::bad_cast Content was not a date
 		 */
-		date as_date() const {
-			std::time_t timestamp;
-			if (get_type() == json::type::number)
-			{
-				timestamp = std::round(as_number());
-			}
-			else
-			{
-				timestamp = as_int();
-			}
-			return std::chrono::system_clock::from_time_t(timestamp);
-		}
+		date as_date() const { return std::chrono::system_clock::from_time_t(get_type() == json::type::number ? std::round(as_number()) : as_int()); }
 
 		/**
 		 * Get the contained JSON value as an array


### PR DESCRIPTION
If the timestamp value for the date is a decimal number, round it to the closest integer. This allows date claims to have a decimal value, though it will be rounded up to the closest second.