### PR TITLE
Allow generic access to JWT header and payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ int main() {
     std::string token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
     auto decoded = jwt::decode(token);
 
-    for(auto& e : decoded.get_payload_claims())
+    for(auto& e : decoded.get_payload_json())
         std::cout << e.first << " = " << e.second << std::endl;
 }
 ```

--- a/example/conan/main.cpp
+++ b/example/conan/main.cpp
@@ -12,6 +12,6 @@ int main() {
 
 	auto decoded = jwt::decode(token);
 
-	for (auto& e : decoded.get_payload_claims())
+	for (auto& e : decoded.get_payload_json())
 		std::cout << e.first << " = " << e.second << std::endl;
 }

--- a/example/es256k.cpp
+++ b/example/es256k.cpp
@@ -34,7 +34,7 @@ K9EDZi0mZ7VUeeNKq476CU5X940yusahgneePQrDMF2nWFEtBCOiXQ==
 	verify.verify(decoded);
 
 	for (auto& e : decoded.get_header_claims())
-		std::cout << e.first << " = " << e.second.to_json() << std::endl;
+		std::cout << e.first << " = " << e.second << std::endl;
 	for (auto& e : decoded.get_payload_claims())
-		std::cout << e.first << " = " << e.second.to_json() << std::endl;
+		std::cout << e.first << " = " << e.second << std::endl;
 }

--- a/example/es256k.cpp
+++ b/example/es256k.cpp
@@ -33,8 +33,8 @@ K9EDZi0mZ7VUeeNKq476CU5X940yusahgneePQrDMF2nWFEtBCOiXQ==
 
 	verify.verify(decoded);
 
-	for (auto& e : decoded.get_header_claims())
+	for (auto& e : decoded.get_header_json())
 		std::cout << e.first << " = " << e.second << std::endl;
-	for (auto& e : decoded.get_payload_claims())
+	for (auto& e : decoded.get_payload_json())
 		std::cout << e.first << " = " << e.second << std::endl;
 }

--- a/example/partial-claim-verifier.cpp
+++ b/example/partial-claim-verifier.cpp
@@ -57,7 +57,7 @@ YwIDAQAB
 
 	auto decoded = jwt::decode(token);
 
-	for (const auto& e : decoded.get_payload_claims())
+	for (const auto& e : decoded.get_payload_json())
 		std::cout << e.first << " = " << e.second << std::endl;
 
 	std::cout << std::endl;

--- a/example/print-claims.cpp
+++ b/example/print-claims.cpp
@@ -6,6 +6,6 @@ int main() {
 		"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.AbIJTDMFc7yUa5MhvcP03nJPyCPzZtQcGEp-zWfOkEE";
 	auto decoded = jwt::decode(token);
 
-	for (auto& e : decoded.get_payload_claims())
+	for (auto& e : decoded.get_payload_json())
 		std::cout << e.first << " = " << e.second << std::endl;
 }

--- a/example/private-claims.cpp
+++ b/example/private-claims.cpp
@@ -32,7 +32,7 @@ int main() {
 
 	const auto decoded = jwt::decode(token);
 
-	const auto api_array = decoded.get_payload_claims()["object"].to_json().get("api").get("array");
+	const auto api_array = decoded.get_payload_claim("object").to_json().get("api").get("array");
 	std::cout << "api array = " << api_array << std::endl;
 
 	jwt::verify()

--- a/example/rsa-verify.cpp
+++ b/example/rsa-verify.cpp
@@ -28,7 +28,7 @@ YwIDAQAB
 	verify.verify(decoded);
 
 	for (auto& e : decoded.get_header_claims())
-		std::cout << e.first << " = " << e.second.to_json() << std::endl;
+		std::cout << e.first << " = " << e.second << std::endl;
 	for (auto& e : decoded.get_payload_claims())
-		std::cout << e.first << " = " << e.second.to_json() << std::endl;
+		std::cout << e.first << " = " << e.second << std::endl;
 }

--- a/example/rsa-verify.cpp
+++ b/example/rsa-verify.cpp
@@ -27,8 +27,8 @@ YwIDAQAB
 
 	verify.verify(decoded);
 
-	for (auto& e : decoded.get_header_claims())
+	for (auto& e : decoded.get_header_json())
 		std::cout << e.first << " = " << e.second << std::endl;
-	for (auto& e : decoded.get_payload_claims())
+	for (auto& e : decoded.get_payload_json())
 		std::cout << e.first << " = " << e.second << std::endl;
 }

--- a/example/traits/boost-json.cpp
+++ b/example/traits/boost-json.cpp
@@ -34,6 +34,10 @@ int main() {
 						   .sign(jwt::algorithm::none{});
 	const auto decoded = jwt::decode<traits>(token);
 
+    for (auto& e : decoded.get_header_claims()) {
+        std::cout << e.key() << " = " << e.value() << std::endl;
+    }
+
 	const auto array =
 		traits::as_array(decoded.get_payload_claim("object").to_json().as_object()["api"].as_object()["array"]);
 	std::cout << "payload /object/api/array = " << array << std::endl;

--- a/example/traits/boost-json.cpp
+++ b/example/traits/boost-json.cpp
@@ -34,9 +34,9 @@ int main() {
 						   .sign(jwt::algorithm::none{});
 	const auto decoded = jwt::decode<traits>(token);
 
-    for (auto& e : decoded.get_header_claims()) {
-        std::cout << e.key() << " = " << e.value() << std::endl;
-    }
+	for (auto& e : decoded.get_header_claims()) {
+		std::cout << e.key() << " = " << e.value() << std::endl;
+	}
 
 	const auto array =
 		traits::as_array(decoded.get_payload_claim("object").to_json().as_object()["api"].as_object()["array"]);

--- a/example/traits/boost-json.cpp
+++ b/example/traits/boost-json.cpp
@@ -34,9 +34,8 @@ int main() {
 						   .sign(jwt::algorithm::none{});
 	const auto decoded = jwt::decode<traits>(token);
 
-	for (auto& e : decoded.get_header_claims()) {
+	for (auto& e : decoded.get_header_claims())
 		std::cout << e.key() << " = " << e.value() << std::endl;
-	}
 
 	const auto array =
 		traits::as_array(decoded.get_payload_claim("object").to_json().as_object()["api"].as_object()["array"]);

--- a/example/traits/boost-json.cpp
+++ b/example/traits/boost-json.cpp
@@ -34,7 +34,7 @@ int main() {
 						   .sign(jwt::algorithm::none{});
 	const auto decoded = jwt::decode<traits>(token);
 
-	for (auto& e : decoded.get_header_claims())
+	for (auto& e : decoded.get_header_json())
 		std::cout << e.key() << " = " << e.value() << std::endl;
 
 	const auto array =

--- a/example/traits/kazuho-picojson.cpp
+++ b/example/traits/kazuho-picojson.cpp
@@ -33,7 +33,7 @@ int main() {
 						   .sign(jwt::algorithm::none{});
 	const auto decoded = jwt::decode<traits>(token);
 
-	const auto api_array = decoded.get_payload_claims("object").get("api").get("array");
+	const auto api_array = decoded.get_payload_claim("object").to_json().get("api").get("array");
 	std::cout << "api array = " << api_array << std::endl;
 
 	jwt::verify<traits>()

--- a/example/traits/kazuho-picojson.cpp
+++ b/example/traits/kazuho-picojson.cpp
@@ -33,7 +33,7 @@ int main() {
 						   .sign(jwt::algorithm::none{});
 	const auto decoded = jwt::decode<traits>(token);
 
-	const auto api_array = decoded.get_payload_claims()["object"].to_json().get("api").get("array");
+	const auto api_array = decoded.get_payload_claims()["object"].get("api").get("array");
 	std::cout << "api array = " << api_array << std::endl;
 
 	jwt::verify<traits>()

--- a/example/traits/kazuho-picojson.cpp
+++ b/example/traits/kazuho-picojson.cpp
@@ -33,7 +33,7 @@ int main() {
 						   .sign(jwt::algorithm::none{});
 	const auto decoded = jwt::decode<traits>(token);
 
-	const auto api_array = decoded.get_payload_claims()["object"].get("api").get("array");
+	const auto api_array = decoded.get_payload_claims("object").get("api").get("array");
 	std::cout << "api array = " << api_array << std::endl;
 
 	jwt::verify<traits>()

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2329,10 +2329,8 @@ namespace jwt {
 
 	namespace details {
 		template<typename json_traits>
-		class map_of_claims {
+		struct map_of_claims {
 			typename json_traits::object_type claims;
-
-		public:
 			using basic_claim_t = basic_claim<json_traits>;
 			using iterator = typename json_traits::object_type::iterator;
 			using const_iterator = typename json_traits::object_type::const_iterator;
@@ -2385,21 +2383,6 @@ namespace jwt {
 			basic_claim_t get_claim(const typename json_traits::string_type& name) const {
 				if (!has_claim(name)) throw error::claim_not_present_exception();
 				return basic_claim_t{claims.at(name)};
-			}
-
-			std::unordered_map<typename json_traits::string_type, basic_claim_t> get_claims() const {
-				static_assert(
-					details::is_valid_json_object<typename json_traits::value_type, typename json_traits::string_type,
-												  typename json_traits::object_type>::supports_claims_transform,
-					"currently there is a limitation on the internal implemantation of the `object_type` to have an "
-					"`std::pair` like `value_type`");
-
-				std::unordered_map<typename json_traits::string_type, basic_claim_t> res;
-				std::transform(claims.begin(), claims.end(), std::inserter(res, res.end()),
-							   [](const typename json_traits::object_type::value_type& val) {
-								   return std::make_pair(val.first, basic_claim_t{val.second});
-							   });
-				return res;
 			}
 		};
 	} // namespace details
@@ -2704,15 +2687,15 @@ namespace jwt {
 		 * Get all payload claims
 		 * \return map of claims
 		 */
-		std::unordered_map<typename json_traits::string_type, basic_claim_t> get_payload_claims() const {
-			return this->payload_claims.get_claims();
+		typename json_traits::obect_type get_payload_claims() const {
+			return this->payload_claims.claims;
 		}
 		/**
 		 * Get all header claims
 		 * \return map of claims
 		 */
-		std::unordered_map<typename json_traits::string_type, basic_claim_t> get_header_claims() const {
-			return this->header_claims.get_claims();
+		typename json_traits::obect_type get_header_claims() const {
+			return this->header_claims.claims;
 		}
 		/**
 		 * Get a payload claim by name
@@ -3589,7 +3572,7 @@ namespace jwt {
 		 * \return Map of claims
 		 */
 		std::unordered_map<typename json_traits::string_type, basic_claim_t> get_claims() const {
-			return this->jwk_claims.get_claims();
+			return this->jwk_claims.claims;
 		}
 	};
 

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2687,16 +2687,12 @@ namespace jwt {
 		 * Get all payload claims
 		 * \return map of claims
 		 */
-		typename json_traits::object_type get_payload_claims() const {
-			return this->payload_claims.claims;
-		}
+		typename json_traits::object_type get_payload_claims() const { return this->payload_claims.claims; }
 		/**
 		 * Get all header claims
 		 * \return map of claims
 		 */
-		typename json_traits::object_type get_header_claims() const {
-			return this->header_claims.claims;
-		}
+		typename json_traits::object_type get_header_claims() const { return this->header_claims.claims; }
 		/**
 		 * Get a payload claim by name
 		 *

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2687,14 +2687,14 @@ namespace jwt {
 		 * Get all payload claims
 		 * \return map of claims
 		 */
-		typename json_traits::obect_type get_payload_claims() const {
+		typename json_traits::object_type get_payload_claims() const {
 			return this->payload_claims.claims;
 		}
 		/**
 		 * Get all header claims
 		 * \return map of claims
 		 */
-		typename json_traits::obect_type get_header_claims() const {
+		typename json_traits::object_type get_header_claims() const {
 			return this->header_claims.claims;
 		}
 		/**

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2102,10 +2102,6 @@ namespace jwt {
 				is_count_signature<object_type, string_type>::value &&
 				is_subcription_operator_signature<object_type, value_type, string_type>::value &&
 				is_at_const_signature<object_type, value_type, string_type>::value;
-
-			static constexpr auto supports_claims_transform =
-				value && is_detected<has_value_type, object_type>::value &&
-				std::is_same<typename object_type::value_type, std::pair<const string_type, value_type>>::value;
 		};
 
 		template<typename value_type, typename array_type>

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -3563,9 +3563,7 @@ namespace jwt {
 		 * Get all jwk claims
 		 * \return Map of claims
 		 */
-		std::unordered_map<typename json_traits::string_type, basic_claim_t> get_claims() const {
-			return this->jwk_claims.claims;
-		}
+		typename json_traits::object_type get_claims() const { return this->jwk_claims.claims; }
 	};
 
 	/**

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2684,15 +2684,15 @@ namespace jwt {
 		 */
 		const typename json_traits::string_type& get_signature_base64() const noexcept { return signature_base64; }
 		/**
-		 * Get all payload claims
+		 * Get all payload as JSON object
 		 * \return map of claims
 		 */
-		typename json_traits::object_type get_payload_claims() const { return this->payload_claims.claims; }
+		typename json_traits::object_type get_payload_json() const { return this->payload_claims.claims; }
 		/**
-		 * Get all header claims
+		 * Get all header as JSON object
 		 * \return map of claims
 		 */
-		typename json_traits::object_type get_header_claims() const { return this->header_claims.claims; }
+		typename json_traits::object_type get_header_json() const { return this->header_claims.claims; }
 		/**
 		 * Get a payload claim by name
 		 *


### PR DESCRIPTION
closes #248 by allow direct access to the JSON. This section of code is only used to debug so it should be better to not have the hassle of the claim wrapping the data