### PR TITLE
NuGet Pkg for v0.6.0 using GitHub Actions

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,37 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Nuget
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+        with:
+          ref: 'v${{ secrets.current_version }}'
+      #   repository: 'diogo-strube/jwt-cpp'
+      
+      # Deploy NuGet so we can call the pack and push cmds
+      - name: Setup NuGet.exe for use with actions
+        uses: NuGet/setup-nuget@v1.0.7
+        with:
+          nuget-api-key: ${{ secrets.nuget_api_key }}
+          
+      # Package the nusepc file
+      - name: Create NuGet pkg
+        run: nuget pack jwt-cpp.nuspec
+        
+      # Publish nuget pkg
+      - name: Publish NuGet pkg
+        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -Version '${{ secrets.current_version }}'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -34,4 +34,4 @@ jobs:
         
       # Publish nuget pkg
       - name: Publish NuGet pkg
-        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -Version '${{ secrets.current_version }}'
+        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -Version '${{ secrets.current_version }}-dev0.1'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -19,7 +19,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
-          ref: 'v0.6.0-dev0.1'
+          ref: 'v0.6.0-dev0.2'
       
       # Deploy NuGet so we can call the pack and push cmds
       - name: Setup NuGet.exe for use with actions
@@ -33,4 +33,4 @@ jobs:
         
       # Publish nuget pkg
       - name: Publish NuGet pkg
-        run: nuget push 'nuget/*.nupkg' -Source 'https://api.nuget.org/v3/index.json' -Version '0.6.0-dev0.1'
+        run: nuget push 'nuget/*.nupkg' -Source 'https://api.nuget.org/v3/index.json' -Version '0.6.0-dev0.2'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -19,8 +19,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
-          ref: 'v${{ secrets.current_version }}'
-      #   repository: 'diogo-strube/jwt-cpp'
+          ref: 'v0.6.0'
       
       # Deploy NuGet so we can call the pack and push cmds
       - name: Setup NuGet.exe for use with actions
@@ -34,4 +33,4 @@ jobs:
         
       # Publish nuget pkg
       - name: Publish NuGet pkg
-        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -Version '${{ secrets.current_version }}-dev0.1'
+        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -Version '0.6.0-dev0.1'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -19,7 +19,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
-          ref: 'v0.6.0-dev0.2'
+          ref: 'v0.6.0'
       
       # Deploy NuGet so we can call the pack and push cmds
       - name: Setup NuGet.exe for use with actions

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -35,5 +35,5 @@ jobs:
       # Publish nuget pkg
       - name: Publish NuGet pkg
         working-directory: ./nuget
-        run: nuget push -Source 'https://api.nuget.org/v3/index.json'
+        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json'
           

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -29,10 +29,11 @@ jobs:
           
       # Package the nusepc file
       - name: Create NuGet pkg
+        working-directory: ./nuget
         run: nuget pack jwt-cpp.nuspec
-          working-directory: ./nuget
         
       # Publish nuget pkg
       - name: Publish NuGet pkg
+        working-directory: ./nuget
         run: nuget push -Source 'https://api.nuget.org/v3/index.json'
-          working-directory: ./nuget
+          

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -29,7 +29,7 @@ jobs:
           
       # Package the nusepc file
       - name: Create NuGet pkg
-        run: nuget pack jwt-cpp.nuspec
+        run: nuget pack 'nuget/jwt-cpp.nuspec'
         
       # Publish nuget pkg
       - name: Publish NuGet pkg

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -33,4 +33,4 @@ jobs:
         
       # Publish nuget pkg
       - name: Publish NuGet pkg
-        run: nuget push 'nuget/*.nupkg' -Source 'https://api.nuget.org/v3/index.json' -Version '0.6.0-dev0.2'
+        run: nuget push 'nuget/*.nupkg' -Source 'https://api.nuget.org/v3/index.json'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -19,7 +19,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
-          ref: 'v0.6.0'
+          ref: 'v0.6.0-dev0.1'
       
       # Deploy NuGet so we can call the pack and push cmds
       - name: Setup NuGet.exe for use with actions

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -29,8 +29,10 @@ jobs:
           
       # Package the nusepc file
       - name: Create NuGet pkg
-        run: nuget pack 'nuget/jwt-cpp.nuspec'
+        run: nuget pack jwt-cpp.nuspec
+          working-directory: ./nuget
         
       # Publish nuget pkg
       - name: Publish NuGet pkg
-        run: nuget push 'nuget/*.nupkg' -Source 'https://api.nuget.org/v3/index.json'
+        run: nuget push -Source 'https://api.nuget.org/v3/index.json'
+          working-directory: ./nuget

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -33,4 +33,4 @@ jobs:
         
       # Publish nuget pkg
       - name: Publish NuGet pkg
-        run: nuget push *.nupkg -Source 'https://api.nuget.org/v3/index.json' -Version '0.6.0-dev0.1'
+        run: nuget push 'nuget/*.nupkg' -Source 'https://api.nuget.org/v3/index.json' -Version '0.6.0-dev0.1'

--- a/nuget/jwt-cpp.nuspec
+++ b/nuget/jwt-cpp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>jwt-cpp</id>
-    <version>0.6.0-dev0.1</version>
+    <version>0.6.0-dev0.2</version>
     <authors>Dominik Thalhammer; Chris Mc</authors>
     <owners>Dominik Thalhammer; Chris Mc</owners>
     <projectUrl>https://github.com/Thalhammer/jwt-cpp</projectUrl>

--- a/nuget/jwt-cpp.nuspec
+++ b/nuget/jwt-cpp.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>jwt-cpp</id>
+    <version>0.6.0-nuget.1</version>
+    <authors>Dominik Thalhammer; Chris Mc</authors>
+    <owners>Dominik Thalhammer; Chris Mc</owners>
+    <projectUrl>https://github.com/Thalhammer/jwt-cpp</projectUrl>
+    <description>JWT++ is a header only library for creating and validating JSON Web Tokens in C++11. This library supports all the algorithms defined by the JWT specifications, and the modular design allows to easily add additional algorithms without any problems. In the name of flexibility and extensibility, jwt-cpp supports OpenSSL, LibreSSL, and wolfSSL. And there is no hard dependency on a JSON library.
+    This library is available under the MIT license. See the link to the license for details.
+    This NuGet Pkg was built with GitHub Workflow https://github.com/diogo-strube/jwt-cpp/blob/master/.github/workflows/nuget.yml.
+    </description>
+    <releaseNotes>Supporting OpenSSL 3.0.0, WolfSSL, Hunter CMake, Boost.JSON, JWKs, ES256K.</releaseNotes>
+    <license type="expression">MIT</license>
+    <copyright>Copyright (c) 2018 Dominik Thalhammer</copyright>
+    <title>JWT++: JSON Web Tokens in C++11</title>
+    <summary>JWT++; a header only library for creating and validating JSON Web Tokens in C++11.</summary>
+    <tags>JWT, json, web, token, C++, header-only</tags>
+    <dependencies>
+      <group targetFramework="native0.0">
+	    <dependency id="PicoJSON" version="1.3.0" />
+	    <dependency id="openssl-vc141-static-x86_64" version="1.1.0" />
+	  </group>
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="..\include\jwt-cpp\**" target="\lib\native\include\jwt-cpp\" />
+    <file src="jwt-cpp.targets" target="\build\native\" />
+    <file src="..\README.md" target="docs\" />
+  </files>
+</package>

--- a/nuget/jwt-cpp.nuspec
+++ b/nuget/jwt-cpp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>jwt-cpp</id>
-    <version>0.6.0-nuget.1</version>
+    <version>0.6.0-dev0.1</version>
     <authors>Dominik Thalhammer; Chris Mc</authors>
     <owners>Dominik Thalhammer; Chris Mc</owners>
     <projectUrl>https://github.com/Thalhammer/jwt-cpp</projectUrl>

--- a/nuget/jwt-cpp.nuspec
+++ b/nuget/jwt-cpp.nuspec
@@ -2,9 +2,9 @@
 <package>
   <metadata>
     <id>jwt-cpp</id>
-    <version>0.6.0</version>
-    <authors>Dominik Thalhammer; Chris Mc</authors>
-    <owners>Dominik Thalhammer; Chris Mc</owners>
+    <version>0.6.0-dev0.2</version>
+    <authors>Thalhammer; prince-chrismc</authors>
+    <owners>Thalhammer; prince-chrismc</owners>
     <projectUrl>https://github.com/Thalhammer/jwt-cpp</projectUrl>
     <description>JWT++ is a header only library for creating and validating JSON Web Tokens in C++11. This library supports all the algorithms defined by the JWT specifications, and the modular design allows to easily add additional algorithms without any problems. In the name of flexibility and extensibility, jwt-cpp supports OpenSSL, LibreSSL, and wolfSSL. And there is no hard dependency on a JSON library.
     </description>

--- a/nuget/jwt-cpp.nuspec
+++ b/nuget/jwt-cpp.nuspec
@@ -2,13 +2,11 @@
 <package>
   <metadata>
     <id>jwt-cpp</id>
-    <version>0.6.0-dev0.2</version>
+    <version>0.6.0</version>
     <authors>Dominik Thalhammer; Chris Mc</authors>
     <owners>Dominik Thalhammer; Chris Mc</owners>
     <projectUrl>https://github.com/Thalhammer/jwt-cpp</projectUrl>
     <description>JWT++ is a header only library for creating and validating JSON Web Tokens in C++11. This library supports all the algorithms defined by the JWT specifications, and the modular design allows to easily add additional algorithms without any problems. In the name of flexibility and extensibility, jwt-cpp supports OpenSSL, LibreSSL, and wolfSSL. And there is no hard dependency on a JSON library.
-    This library is available under the MIT license. See the link to the license for details.
-    This NuGet Pkg was built with GitHub Workflow https://github.com/diogo-strube/jwt-cpp/blob/master/.github/workflows/nuget.yml.
     </description>
     <releaseNotes>Supporting OpenSSL 3.0.0, WolfSSL, Hunter CMake, Boost.JSON, JWKs, ES256K.</releaseNotes>
     <license type="expression">MIT</license>

--- a/nuget/jwt-cpp.targets
+++ b/nuget/jwt-cpp.targets
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\lib\native\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
This PR is related to discussion #243 and is a 3 file contribution:
- nuget\jwt-cpp.nuspec contains all the descriptions of the NuGet package, including authors, and the path of files to be copied.
- nuget\jwt-cpp.targets automatically set up the "additional include directories" when the package is installed.
- .github\workflows\nuget.yml contains the GitHub Action to pack and pub the NuGet package.

Some context on the current approach:
- As the version is already tracked by committed files (as shown in #208), I left the version explicit in the .nuspec file (instead of using an environment variable or secret).
- Publishing a NuGet pkg (to nugte.org) requires a token, the same was configured as a secret ${{ secrets.nuget_api_key }} in .github\workflows\nuget.yml.