### PR TITLE
std::string_view support

### DIFF
--- a/docs/traits.md
+++ b/docs/traits.md
@@ -54,7 +54,8 @@ struct my_favorite_json_library_traits {
     static boolean_type as_boolean(const value_type &val);
 
     // serialization and parsing
-    static bool parse(value_type &val, string_type str);
+    template <class string_t> // could be the json string_type, or std::string_view for instance
+    static bool parse(value_type &val, const string_t& str);
     static string_type serialize(const value_type &val); // with no extra whitespace, padding or indentation
 };
 ```

--- a/include/jwt-cpp/string_types.h
+++ b/include/jwt-cpp/string_types.h
@@ -1,0 +1,21 @@
+#ifndef STRING_TYPES_H
+#define STRING_TYPES_H
+
+#if __cplusplus >= 201703L
+
+#include <string_view>
+
+#define JWT_HAS_STRING_VIEW
+namespace jwt {
+	using string_view = std::string_view;
+}
+
+#else
+
+#include <string>
+namespace jwt {
+	using string_view = const std::string&;
+}
+#endif
+
+#endif

--- a/include/jwt-cpp/traits/boost-json/traits.h
+++ b/include/jwt-cpp/traits/boost-json/traits.h
@@ -67,7 +67,8 @@ namespace jwt {
 				return val.get_double();
 			}
 
-			static bool parse(value_type& val, string_type str) {
+			template<class string_t>
+			static bool parse(value_type& val, const string_t& str) {
 				val = json::parse(str);
 				return true;
 			}

--- a/include/jwt-cpp/traits/danielaparker-jsoncons/traits.h
+++ b/include/jwt-cpp/traits/danielaparker-jsoncons/traits.h
@@ -108,7 +108,8 @@ namespace jwt {
 				return val.as_bool();
 			}
 
-			static bool parse(json& val, const std::string& str) {
+			template<class string_t>
+			static bool parse(json& val, const string_t& str) {
 				val = json::parse(str);
 				return true;
 			}

--- a/include/jwt-cpp/traits/kazuho-picojson/traits.h
+++ b/include/jwt-cpp/traits/kazuho-picojson/traits.h
@@ -64,7 +64,8 @@ namespace jwt {
 				return val.get<double>();
 			}
 
-			static bool parse(picojson::value& val, const std::string& str) {
+			template<class string_t>
+			static bool parse(picojson::value& val, const string_t& str) {
 				return picojson::parse(val, str).empty();
 			}
 

--- a/include/jwt-cpp/traits/nlohmann-json/traits.h
+++ b/include/jwt-cpp/traits/nlohmann-json/traits.h
@@ -64,7 +64,8 @@ namespace jwt {
 				return val.get<double>();
 			}
 
-			static bool parse(json& val, std::string str) {
+			template<class string_t>
+			static bool parse(json& val, const string_t& str) {
 				val = json::parse(str.begin(), str.end());
 				return true;
 			}

--- a/tests/BaseTest.cpp
+++ b/tests/BaseTest.cpp
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 
 namespace jwt {
-
 	namespace base {
 		namespace details {
 			inline bool operator==(const padding& lhs, const padding& rhs) {
@@ -10,136 +9,141 @@ namespace jwt {
 			}
 		} // namespace details
 	}	  // namespace base
-
-	namespace {
-		base::details::padding count_padding(string_view base, std::initializer_list<std::string> fills) {
-			return base::details::count_padding(base, fills.begin(), fills.end());
-		}
-	} // namespace
-
-	TEST(BaseTest, Base64Index) {
-#ifdef JWT_HAS_STRING_VIEW
-		ASSERT_EQ(0, alphabet::index(std::begin(alphabet::base64::kData), std::end(alphabet::base64::kData), 'A'));
-		ASSERT_EQ(32, alphabet::index(std::begin(alphabet::base64::kData), std::end(alphabet::base64::kData), 'g'));
-		ASSERT_EQ(62, alphabet::index(std::begin(alphabet::base64::kData), std::end(alphabet::base64::kData), '+'));
-#else
-		ASSERT_EQ(0, alphabet::index(std::begin(alphabet::base64::data()), std::end(alphabet::base64::data()), 'A'));
-		ASSERT_EQ(32, alphabet::index(std::begin(alphabet::base64::data()), std::end(alphabet::base64::data()), 'g'));
-		ASSERT_EQ(62, alphabet::index(std::begin(alphabet::base64::data()), std::end(alphabet::base64::data()), '+'));
-#endif
-	}
-
-	TEST(BaseTest, Base64URLIndex) {
-#ifdef JWT_HAS_STRING_VIEW
-		ASSERT_EQ(0,
-				  alphabet::index(std::begin(alphabet::base64url::kData), std::end(alphabet::base64url::kData), 'A'));
-		ASSERT_EQ(32,
-				  alphabet::index(std::begin(alphabet::base64url::kData), std::end(alphabet::base64url::kData), 'g'));
-		ASSERT_EQ(62,
-				  alphabet::index(std::begin(alphabet::base64url::kData), std::end(alphabet::base64url::kData), '-'));
-#else
-		ASSERT_EQ(0,
-				  alphabet::index(std::begin(alphabet::base64url::data()), std::end(alphabet::base64url::data()), 'A'));
-		ASSERT_EQ(32,
-				  alphabet::index(std::begin(alphabet::base64url::data()), std::end(alphabet::base64url::data()), 'g'));
-		ASSERT_EQ(62,
-				  alphabet::index(std::begin(alphabet::base64url::data()), std::end(alphabet::base64url::data()), '-'));
-#endif
-	}
-
-	TEST(BaseTest, BaseDetailsCountPadding) {
-		using base::details::padding;
-		ASSERT_EQ(padding{}, count_padding("ABC", {"~"}));
-		ASSERT_EQ((padding{3, 3}), count_padding("ABC~~~", {"~"}));
-		ASSERT_EQ((padding{5, 5}), count_padding("ABC~~~~~", {"~"}));
-
-		ASSERT_EQ(padding{}, count_padding("ABC", {"~", "!"}));
-		ASSERT_EQ((padding{1, 1}), count_padding("ABC!", {"~", "!"}));
-		ASSERT_EQ((padding{1, 1}), count_padding("ABC~", {"~", "!"}));
-		ASSERT_EQ((padding{3, 3}), count_padding("ABC~~!", {"~", "!"}));
-		ASSERT_EQ((padding{3, 3}), count_padding("ABC!~~", {"~", "!"}));
-		ASSERT_EQ((padding{5, 5}), count_padding("ABC~~!~~", {"~", "!"}));
-
-		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3d%3d", {"%3d", "%3D"}));
-		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3d%3D", {"%3d", "%3D"}));
-		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3D%3d", {"%3d", "%3D"}));
-		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3D%3D", {"%3d", "%3D"}));
-
-		// Some fake scenarios
-
-		ASSERT_EQ(padding{}, count_padding("", {"~"}));
-		ASSERT_EQ(padding{}, count_padding("ABC", {"~", "~~!"}));
-		ASSERT_EQ(padding{}, count_padding("ABC!", {"~", "~~!"}));
-		ASSERT_EQ((padding{1, 1}), count_padding("ABC~", {"~", "~~!"}));
-		ASSERT_EQ((padding{1, 3}), count_padding("ABC~~!", {"~", "~~!"}));
-		ASSERT_EQ((padding{2, 2}), count_padding("ABC!~~", {"~", "~~!"}));
-		ASSERT_EQ((padding{3, 5}), count_padding("ABC~~!~~", {"~", "~~!"}));
-		ASSERT_EQ(padding{}, count_padding("ABC~~!~~", {}));
-	}
-
-	TEST(BaseTest, Base64Decode) {
-		ASSERT_EQ("1", base::decode<alphabet::base64>("MQ=="));
-		ASSERT_EQ("12", base::decode<alphabet::base64>("MTI="));
-		ASSERT_EQ("123", base::decode<alphabet::base64>("MTIz"));
-		ASSERT_EQ("1234", base::decode<alphabet::base64>("MTIzNA=="));
-	}
-
-	TEST(BaseTest, Base64DecodeURL) {
-		ASSERT_EQ("1", base::decode<alphabet::base64url>("MQ%3d%3d"));
-		ASSERT_EQ("12", base::decode<alphabet::base64url>("MTI%3d"));
-		ASSERT_EQ("123", base::decode<alphabet::base64url>("MTIz"));
-		ASSERT_EQ("1234", base::decode<alphabet::base64url>("MTIzNA%3d%3d"));
-	}
-
-	TEST(BaseTest, Base64DecodeURLCaseInsensitive) {
-		ASSERT_EQ("1", base::decode<alphabet::helper::base64url_percent_encoding>("MQ%3d%3d"));
-		ASSERT_EQ("1", base::decode<alphabet::helper::base64url_percent_encoding>("MQ%3D%3d"));
-		ASSERT_EQ("1", base::decode<alphabet::helper::base64url_percent_encoding>("MQ%3d%3D"));
-		ASSERT_EQ("12", base::decode<alphabet::helper::base64url_percent_encoding>("MTI%3d"));
-		ASSERT_EQ("123", base::decode<alphabet::helper::base64url_percent_encoding>("MTIz"));
-		ASSERT_EQ("1234", base::decode<alphabet::helper::base64url_percent_encoding>("MTIzNA%3d%3d"));
-		ASSERT_EQ("1234", base::decode<alphabet::helper::base64url_percent_encoding>("MTIzNA%3D%3D"));
-	}
-
-	TEST(BaseTest, Base64Encode) {
-		ASSERT_EQ("MQ==", base::encode<alphabet::base64>("1"));
-		ASSERT_EQ("MTI=", base::encode<alphabet::base64>("12"));
-		ASSERT_EQ("MTIz", base::encode<alphabet::base64>("123"));
-		ASSERT_EQ("MTIzNA==", base::encode<alphabet::base64>("1234"));
-	}
-
-	TEST(BaseTest, Base64EncodeURL) {
-		ASSERT_EQ("MQ%3d%3d", base::encode<alphabet::base64url>("1"));
-		ASSERT_EQ("MTI%3d", base::encode<alphabet::base64url>("12"));
-		ASSERT_EQ("MTIz", base::encode<alphabet::base64url>("123"));
-		ASSERT_EQ("MTIzNA%3d%3d", base::encode<alphabet::base64url>("1234"));
-	}
-
-	TEST(BaseTest, Base64Pad) {
-		ASSERT_EQ("MQ==", base::pad<alphabet::base64>("MQ"));
-		ASSERT_EQ("MTI=", base::pad<alphabet::base64>("MTI"));
-		ASSERT_EQ("MTIz", base::pad<alphabet::base64>("MTIz"));
-		ASSERT_EQ("MTIzNA==", base::pad<alphabet::base64>("MTIzNA"));
-	}
-
-	TEST(BaseTest, Base64PadURL) {
-		ASSERT_EQ("MQ%3d%3d", base::pad<alphabet::base64url>("MQ"));
-		ASSERT_EQ("MTI%3d", base::pad<alphabet::base64url>("MTI"));
-		ASSERT_EQ("MTIz", base::pad<alphabet::base64url>("MTIz"));
-		ASSERT_EQ("MTIzNA%3d%3d", base::pad<alphabet::base64url>("MTIzNA"));
-	}
-
-	TEST(BaseTest, Base64Trim) {
-		ASSERT_EQ("MQ", base::trim<alphabet::base64>("MQ=="));
-		ASSERT_EQ("MTI", base::trim<alphabet::base64>("MTI="));
-		ASSERT_EQ("MTIz", base::trim<alphabet::base64>("MTIz"));
-		ASSERT_EQ("MTIzNA", base::trim<alphabet::base64>("MTIzNA=="));
-	}
-
-	TEST(BaseTest, Base64TrimURL) {
-		ASSERT_EQ("MQ", base::trim<alphabet::base64url>("MQ%3d%3d"));
-		ASSERT_EQ("MTI", base::trim<alphabet::base64url>("MTI%3d"));
-		ASSERT_EQ("MTIz", base::trim<alphabet::base64url>("MTIz"));
-		ASSERT_EQ("MTIzNA", base::trim<alphabet::base64url>("MTIzNA%3d%3d"));
-	}
 } // namespace jwt
+namespace {
+	jwt::base::details::padding count_padding(jwt::string_view base, std::initializer_list<std::string> fills) {
+		return jwt::base::details::count_padding(base, fills.begin(), fills.end());
+	}
+} // namespace
+
+TEST(BaseTest, Base64Index) {
+#ifdef JWT_HAS_STRING_VIEW
+	ASSERT_EQ(
+		0, jwt::alphabet::index(std::begin(jwt::alphabet::base64::kData), std::end(jwt::alphabet::base64::kData), 'A'));
+	ASSERT_EQ(32, jwt::alphabet::index(std::begin(jwt::alphabet::base64::kData), std::end(jwt::alphabet::base64::kData),
+									   'g'));
+	ASSERT_EQ(62, jwt::alphabet::index(std::begin(jwt::alphabet::base64::kData), std::end(jwt::alphabet::base64::kData),
+									   '+'));
+#else
+	ASSERT_EQ(0, jwt::alphabet::index(std::begin(jwt::alphabet::base64::data()),
+									  std::end(jwt::alphabet::base64::data()), 'A'));
+	ASSERT_EQ(32, jwt::alphabet::index(std::begin(jwt::alphabet::base64::data()),
+									   std::end(jwt::alphabet::base64::data()), 'g'));
+	ASSERT_EQ(62, jwt::alphabet::index(std::begin(jwt::alphabet::base64::data()),
+									   std::end(jwt::alphabet::base64::data()), '+'));
+#endif
+}
+
+TEST(BaseTest, Base64URLIndex) {
+#ifdef JWT_HAS_STRING_VIEW
+	ASSERT_EQ(0, jwt::alphabet::index(std::begin(jwt::alphabet::base64url::kData),
+									  std::end(jwt::alphabet::base64url::kData), 'A'));
+	ASSERT_EQ(32, jwt::alphabet::index(std::begin(jwt::alphabet::base64url::kData),
+									   std::end(jwt::alphabet::base64url::kData), 'g'));
+	ASSERT_EQ(62, jwt::alphabet::index(std::begin(jwt::alphabet::base64url::kData),
+									   std::end(jwt::alphabet::base64url::kData), '-'));
+#else
+	ASSERT_EQ(0, jwt::alphabet::index(std::begin(jwt::alphabet::base64url::data()),
+									  std::end(jwt::alphabet::base64url::data()), 'A'));
+	ASSERT_EQ(32, jwt::alphabet::index(std::begin(jwt::alphabet::base64url::data()),
+									   std::end(jwt::alphabet::base64url::data()), 'g'));
+	ASSERT_EQ(62, jwt::alphabet::index(std::begin(jwt::alphabet::base64url::data()),
+									   std::end(jwt::alphabet::base64url::data()), '-'));
+#endif
+}
+
+TEST(BaseTest, BaseDetailsCountPadding) {
+	using jwt::base::details::padding;
+	ASSERT_EQ(padding{}, count_padding("ABC", {"~"}));
+	ASSERT_EQ((padding{3, 3}), count_padding("ABC~~~", {"~"}));
+	ASSERT_EQ((padding{5, 5}), count_padding("ABC~~~~~", {"~"}));
+
+	ASSERT_EQ(padding{}, count_padding("ABC", {"~", "!"}));
+	ASSERT_EQ((padding{1, 1}), count_padding("ABC!", {"~", "!"}));
+	ASSERT_EQ((padding{1, 1}), count_padding("ABC~", {"~", "!"}));
+	ASSERT_EQ((padding{3, 3}), count_padding("ABC~~!", {"~", "!"}));
+	ASSERT_EQ((padding{3, 3}), count_padding("ABC!~~", {"~", "!"}));
+	ASSERT_EQ((padding{5, 5}), count_padding("ABC~~!~~", {"~", "!"}));
+
+	ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3d%3d", {"%3d", "%3D"}));
+	ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3d%3D", {"%3d", "%3D"}));
+	ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3D%3d", {"%3d", "%3D"}));
+	ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3D%3D", {"%3d", "%3D"}));
+
+	// Some fake scenarios
+
+	ASSERT_EQ(padding{}, count_padding("", {"~"}));
+	ASSERT_EQ(padding{}, count_padding("ABC", {"~", "~~!"}));
+	ASSERT_EQ(padding{}, count_padding("ABC!", {"~", "~~!"}));
+	ASSERT_EQ((padding{1, 1}), count_padding("ABC~", {"~", "~~!"}));
+	ASSERT_EQ((padding{1, 3}), count_padding("ABC~~!", {"~", "~~!"}));
+	ASSERT_EQ((padding{2, 2}), count_padding("ABC!~~", {"~", "~~!"}));
+	ASSERT_EQ((padding{3, 5}), count_padding("ABC~~!~~", {"~", "~~!"}));
+	ASSERT_EQ(padding{}, count_padding("ABC~~!~~", {}));
+}
+
+TEST(BaseTest, Base64Decode) {
+	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::base64>("MQ=="));
+	ASSERT_EQ("12", jwt::base::decode<jwt::alphabet::base64>("MTI="));
+	ASSERT_EQ("123", jwt::base::decode<jwt::alphabet::base64>("MTIz"));
+	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::base64>("MTIzNA=="));
+}
+
+TEST(BaseTest, Base64DecodeURL) {
+	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::base64url>("MQ%3d%3d"));
+	ASSERT_EQ("12", jwt::base::decode<jwt::alphabet::base64url>("MTI%3d"));
+	ASSERT_EQ("123", jwt::base::decode<jwt::alphabet::base64url>("MTIz"));
+	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::base64url>("MTIzNA%3d%3d"));
+}
+
+TEST(BaseTest, Base64DecodeURLCaseInsensitive) {
+	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MQ%3d%3d"));
+	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MQ%3D%3d"));
+	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MQ%3d%3D"));
+	ASSERT_EQ("12", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTI%3d"));
+	ASSERT_EQ("123", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTIz"));
+	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTIzNA%3d%3d"));
+	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTIzNA%3D%3D"));
+}
+
+TEST(BaseTest, Base64Encode) {
+	ASSERT_EQ("MQ==", jwt::base::encode<jwt::alphabet::base64>("1"));
+	ASSERT_EQ("MTI=", jwt::base::encode<jwt::alphabet::base64>("12"));
+	ASSERT_EQ("MTIz", jwt::base::encode<jwt::alphabet::base64>("123"));
+	ASSERT_EQ("MTIzNA==", jwt::base::encode<jwt::alphabet::base64>("1234"));
+}
+
+TEST(BaseTest, Base64EncodeURL) {
+	ASSERT_EQ("MQ%3d%3d", jwt::base::encode<jwt::alphabet::base64url>("1"));
+	ASSERT_EQ("MTI%3d", jwt::base::encode<jwt::alphabet::base64url>("12"));
+	ASSERT_EQ("MTIz", jwt::base::encode<jwt::alphabet::base64url>("123"));
+	ASSERT_EQ("MTIzNA%3d%3d", jwt::base::encode<jwt::alphabet::base64url>("1234"));
+}
+
+TEST(BaseTest, Base64Pad) {
+	ASSERT_EQ("MQ==", jwt::base::pad<jwt::alphabet::base64>("MQ"));
+	ASSERT_EQ("MTI=", jwt::base::pad<jwt::alphabet::base64>("MTI"));
+	ASSERT_EQ("MTIz", jwt::base::pad<jwt::alphabet::base64>("MTIz"));
+	ASSERT_EQ("MTIzNA==", jwt::base::pad<jwt::alphabet::base64>("MTIzNA"));
+}
+
+TEST(BaseTest, Base64PadURL) {
+	ASSERT_EQ("MQ%3d%3d", jwt::base::pad<jwt::alphabet::base64url>("MQ"));
+	ASSERT_EQ("MTI%3d", jwt::base::pad<jwt::alphabet::base64url>("MTI"));
+	ASSERT_EQ("MTIz", jwt::base::pad<jwt::alphabet::base64url>("MTIz"));
+	ASSERT_EQ("MTIzNA%3d%3d", jwt::base::pad<jwt::alphabet::base64url>("MTIzNA"));
+}
+
+TEST(BaseTest, Base64Trim) {
+	ASSERT_EQ("MQ", jwt::base::trim<jwt::alphabet::base64>("MQ=="));
+	ASSERT_EQ("MTI", jwt::base::trim<jwt::alphabet::base64>("MTI="));
+	ASSERT_EQ("MTIz", jwt::base::trim<jwt::alphabet::base64>("MTIz"));
+	ASSERT_EQ("MTIzNA", jwt::base::trim<jwt::alphabet::base64>("MTIzNA=="));
+}
+
+TEST(BaseTest, Base64TrimURL) {
+	ASSERT_EQ("MQ", jwt::base::trim<jwt::alphabet::base64url>("MQ%3d%3d"));
+	ASSERT_EQ("MTI", jwt::base::trim<jwt::alphabet::base64url>("MTI%3d"));
+	ASSERT_EQ("MTIz", jwt::base::trim<jwt::alphabet::base64url>("MTIz"));
+	ASSERT_EQ("MTIzNA", jwt::base::trim<jwt::alphabet::base64url>("MTIzNA%3d%3d"));
+}

--- a/tests/BaseTest.cpp
+++ b/tests/BaseTest.cpp
@@ -1,110 +1,145 @@
 #include "jwt-cpp/base.h"
 #include <gtest/gtest.h>
 
-TEST(BaseTest, Base64Index) {
-	ASSERT_EQ(0, jwt::alphabet::index(jwt::alphabet::base64::data(), 'A'));
-	ASSERT_EQ(32, jwt::alphabet::index(jwt::alphabet::base64::data(), 'g'));
-	ASSERT_EQ(62, jwt::alphabet::index(jwt::alphabet::base64::data(), '+'));
-}
+namespace jwt {
 
-TEST(BaseTest, Base64URLIndex) {
-	ASSERT_EQ(0, jwt::alphabet::index(jwt::alphabet::base64url::data(), 'A'));
-	ASSERT_EQ(32, jwt::alphabet::index(jwt::alphabet::base64url::data(), 'g'));
-	ASSERT_EQ(62, jwt::alphabet::index(jwt::alphabet::base64url::data(), '-'));
-}
+	namespace base {
+		namespace details {
+			inline bool operator==(const padding& lhs, const padding& rhs) {
+				return lhs.count == rhs.count && lhs.length == rhs.length;
+			}
+		} // namespace details
+	}	  // namespace base
 
-TEST(BaseTest, BaseDetailsCountPadding) {
-	using jwt::base::details::padding;
-	ASSERT_EQ(padding{}, jwt::base::details::count_padding("ABC", {"~"}));
-	ASSERT_EQ((padding{3, 3}), jwt::base::details::count_padding("ABC~~~", {"~"}));
-	ASSERT_EQ((padding{5, 5}), jwt::base::details::count_padding("ABC~~~~~", {"~"}));
+	namespace {
+		base::details::padding count_padding(string_view base, std::initializer_list<std::string> fills) {
+			return base::details::count_padding(base, fills.begin(), fills.end());
+		}
+	} // namespace
 
-	ASSERT_EQ(padding{}, jwt::base::details::count_padding("ABC", {"~", "!"}));
-	ASSERT_EQ((padding{1, 1}), jwt::base::details::count_padding("ABC!", {"~", "!"}));
-	ASSERT_EQ((padding{1, 1}), jwt::base::details::count_padding("ABC~", {"~", "!"}));
-	ASSERT_EQ((padding{3, 3}), jwt::base::details::count_padding("ABC~~!", {"~", "!"}));
-	ASSERT_EQ((padding{3, 3}), jwt::base::details::count_padding("ABC!~~", {"~", "!"}));
-	ASSERT_EQ((padding{5, 5}), jwt::base::details::count_padding("ABC~~!~~", {"~", "!"}));
+	TEST(BaseTest, Base64Index) {
+#ifdef JWT_HAS_STRING_VIEW
+		ASSERT_EQ(0, alphabet::index(std::begin(alphabet::base64::kData), std::end(alphabet::base64::kData), 'A'));
+		ASSERT_EQ(32, alphabet::index(std::begin(alphabet::base64::kData), std::end(alphabet::base64::kData), 'g'));
+		ASSERT_EQ(62, alphabet::index(std::begin(alphabet::base64::kData), std::end(alphabet::base64::kData), '+'));
+#else
+		ASSERT_EQ(0, alphabet::index(std::begin(alphabet::base64::data()), std::end(alphabet::base64::data()), 'A'));
+		ASSERT_EQ(32, alphabet::index(std::begin(alphabet::base64::data()), std::end(alphabet::base64::data()), 'g'));
+		ASSERT_EQ(62, alphabet::index(std::begin(alphabet::base64::data()), std::end(alphabet::base64::data()), '+'));
+#endif
+	}
 
-	ASSERT_EQ((padding{2, 6}), jwt::base::details::count_padding("MTIzNA%3d%3d", {"%3d", "%3D"}));
-	ASSERT_EQ((padding{2, 6}), jwt::base::details::count_padding("MTIzNA%3d%3D", {"%3d", "%3D"}));
-	ASSERT_EQ((padding{2, 6}), jwt::base::details::count_padding("MTIzNA%3D%3d", {"%3d", "%3D"}));
-	ASSERT_EQ((padding{2, 6}), jwt::base::details::count_padding("MTIzNA%3D%3D", {"%3d", "%3D"}));
+	TEST(BaseTest, Base64URLIndex) {
+#ifdef JWT_HAS_STRING_VIEW
+		ASSERT_EQ(0,
+				  alphabet::index(std::begin(alphabet::base64url::kData), std::end(alphabet::base64url::kData), 'A'));
+		ASSERT_EQ(32,
+				  alphabet::index(std::begin(alphabet::base64url::kData), std::end(alphabet::base64url::kData), 'g'));
+		ASSERT_EQ(62,
+				  alphabet::index(std::begin(alphabet::base64url::kData), std::end(alphabet::base64url::kData), '-'));
+#else
+		ASSERT_EQ(0,
+				  alphabet::index(std::begin(alphabet::base64url::data()), std::end(alphabet::base64url::data()), 'A'));
+		ASSERT_EQ(32,
+				  alphabet::index(std::begin(alphabet::base64url::data()), std::end(alphabet::base64url::data()), 'g'));
+		ASSERT_EQ(62,
+				  alphabet::index(std::begin(alphabet::base64url::data()), std::end(alphabet::base64url::data()), '-'));
+#endif
+	}
 
-	// Some fake scenarios
+	TEST(BaseTest, BaseDetailsCountPadding) {
+		using base::details::padding;
+		ASSERT_EQ(padding{}, count_padding("ABC", {"~"}));
+		ASSERT_EQ((padding{3, 3}), count_padding("ABC~~~", {"~"}));
+		ASSERT_EQ((padding{5, 5}), count_padding("ABC~~~~~", {"~"}));
 
-	ASSERT_EQ(padding{}, jwt::base::details::count_padding("", {"~"}));
-	ASSERT_EQ(padding{}, jwt::base::details::count_padding("ABC", {"~", "~~!"}));
-	ASSERT_EQ(padding{}, jwt::base::details::count_padding("ABC!", {"~", "~~!"}));
-	ASSERT_EQ((padding{1, 1}), jwt::base::details::count_padding("ABC~", {"~", "~~!"}));
-	ASSERT_EQ((padding{1, 3}), jwt::base::details::count_padding("ABC~~!", {"~", "~~!"}));
-	ASSERT_EQ((padding{2, 2}), jwt::base::details::count_padding("ABC!~~", {"~", "~~!"}));
-	ASSERT_EQ((padding{3, 5}), jwt::base::details::count_padding("ABC~~!~~", {"~", "~~!"}));
-	ASSERT_EQ(padding{}, jwt::base::details::count_padding("ABC~~!~~", {}));
-}
+		ASSERT_EQ(padding{}, count_padding("ABC", {"~", "!"}));
+		ASSERT_EQ((padding{1, 1}), count_padding("ABC!", {"~", "!"}));
+		ASSERT_EQ((padding{1, 1}), count_padding("ABC~", {"~", "!"}));
+		ASSERT_EQ((padding{3, 3}), count_padding("ABC~~!", {"~", "!"}));
+		ASSERT_EQ((padding{3, 3}), count_padding("ABC!~~", {"~", "!"}));
+		ASSERT_EQ((padding{5, 5}), count_padding("ABC~~!~~", {"~", "!"}));
 
-TEST(BaseTest, Base64Decode) {
-	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::base64>("MQ=="));
-	ASSERT_EQ("12", jwt::base::decode<jwt::alphabet::base64>("MTI="));
-	ASSERT_EQ("123", jwt::base::decode<jwt::alphabet::base64>("MTIz"));
-	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::base64>("MTIzNA=="));
-}
+		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3d%3d", {"%3d", "%3D"}));
+		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3d%3D", {"%3d", "%3D"}));
+		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3D%3d", {"%3d", "%3D"}));
+		ASSERT_EQ((padding{2, 6}), count_padding("MTIzNA%3D%3D", {"%3d", "%3D"}));
 
-TEST(BaseTest, Base64DecodeURL) {
-	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::base64url>("MQ%3d%3d"));
-	ASSERT_EQ("12", jwt::base::decode<jwt::alphabet::base64url>("MTI%3d"));
-	ASSERT_EQ("123", jwt::base::decode<jwt::alphabet::base64url>("MTIz"));
-	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::base64url>("MTIzNA%3d%3d"));
-}
+		// Some fake scenarios
 
-TEST(BaseTest, Base64DecodeURLCaseInsensitive) {
-	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MQ%3d%3d"));
-	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MQ%3D%3d"));
-	ASSERT_EQ("1", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MQ%3d%3D"));
-	ASSERT_EQ("12", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTI%3d"));
-	ASSERT_EQ("123", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTIz"));
-	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTIzNA%3d%3d"));
-	ASSERT_EQ("1234", jwt::base::decode<jwt::alphabet::helper::base64url_percent_encoding>("MTIzNA%3D%3D"));
-}
+		ASSERT_EQ(padding{}, count_padding("", {"~"}));
+		ASSERT_EQ(padding{}, count_padding("ABC", {"~", "~~!"}));
+		ASSERT_EQ(padding{}, count_padding("ABC!", {"~", "~~!"}));
+		ASSERT_EQ((padding{1, 1}), count_padding("ABC~", {"~", "~~!"}));
+		ASSERT_EQ((padding{1, 3}), count_padding("ABC~~!", {"~", "~~!"}));
+		ASSERT_EQ((padding{2, 2}), count_padding("ABC!~~", {"~", "~~!"}));
+		ASSERT_EQ((padding{3, 5}), count_padding("ABC~~!~~", {"~", "~~!"}));
+		ASSERT_EQ(padding{}, count_padding("ABC~~!~~", {}));
+	}
 
-TEST(BaseTest, Base64Encode) {
-	ASSERT_EQ("MQ==", jwt::base::encode<jwt::alphabet::base64>("1"));
-	ASSERT_EQ("MTI=", jwt::base::encode<jwt::alphabet::base64>("12"));
-	ASSERT_EQ("MTIz", jwt::base::encode<jwt::alphabet::base64>("123"));
-	ASSERT_EQ("MTIzNA==", jwt::base::encode<jwt::alphabet::base64>("1234"));
-}
+	TEST(BaseTest, Base64Decode) {
+		ASSERT_EQ("1", base::decode<alphabet::base64>("MQ=="));
+		ASSERT_EQ("12", base::decode<alphabet::base64>("MTI="));
+		ASSERT_EQ("123", base::decode<alphabet::base64>("MTIz"));
+		ASSERT_EQ("1234", base::decode<alphabet::base64>("MTIzNA=="));
+	}
 
-TEST(BaseTest, Base64EncodeURL) {
-	ASSERT_EQ("MQ%3d%3d", jwt::base::encode<jwt::alphabet::base64url>("1"));
-	ASSERT_EQ("MTI%3d", jwt::base::encode<jwt::alphabet::base64url>("12"));
-	ASSERT_EQ("MTIz", jwt::base::encode<jwt::alphabet::base64url>("123"));
-	ASSERT_EQ("MTIzNA%3d%3d", jwt::base::encode<jwt::alphabet::base64url>("1234"));
-}
+	TEST(BaseTest, Base64DecodeURL) {
+		ASSERT_EQ("1", base::decode<alphabet::base64url>("MQ%3d%3d"));
+		ASSERT_EQ("12", base::decode<alphabet::base64url>("MTI%3d"));
+		ASSERT_EQ("123", base::decode<alphabet::base64url>("MTIz"));
+		ASSERT_EQ("1234", base::decode<alphabet::base64url>("MTIzNA%3d%3d"));
+	}
 
-TEST(BaseTest, Base64Pad) {
-	ASSERT_EQ("MQ==", jwt::base::pad<jwt::alphabet::base64>("MQ"));
-	ASSERT_EQ("MTI=", jwt::base::pad<jwt::alphabet::base64>("MTI"));
-	ASSERT_EQ("MTIz", jwt::base::pad<jwt::alphabet::base64>("MTIz"));
-	ASSERT_EQ("MTIzNA==", jwt::base::pad<jwt::alphabet::base64>("MTIzNA"));
-}
+	TEST(BaseTest, Base64DecodeURLCaseInsensitive) {
+		ASSERT_EQ("1", base::decode<alphabet::helper::base64url_percent_encoding>("MQ%3d%3d"));
+		ASSERT_EQ("1", base::decode<alphabet::helper::base64url_percent_encoding>("MQ%3D%3d"));
+		ASSERT_EQ("1", base::decode<alphabet::helper::base64url_percent_encoding>("MQ%3d%3D"));
+		ASSERT_EQ("12", base::decode<alphabet::helper::base64url_percent_encoding>("MTI%3d"));
+		ASSERT_EQ("123", base::decode<alphabet::helper::base64url_percent_encoding>("MTIz"));
+		ASSERT_EQ("1234", base::decode<alphabet::helper::base64url_percent_encoding>("MTIzNA%3d%3d"));
+		ASSERT_EQ("1234", base::decode<alphabet::helper::base64url_percent_encoding>("MTIzNA%3D%3D"));
+	}
 
-TEST(BaseTest, Base64PadURL) {
-	ASSERT_EQ("MQ%3d%3d", jwt::base::pad<jwt::alphabet::base64url>("MQ"));
-	ASSERT_EQ("MTI%3d", jwt::base::pad<jwt::alphabet::base64url>("MTI"));
-	ASSERT_EQ("MTIz", jwt::base::pad<jwt::alphabet::base64url>("MTIz"));
-	ASSERT_EQ("MTIzNA%3d%3d", jwt::base::pad<jwt::alphabet::base64url>("MTIzNA"));
-}
+	TEST(BaseTest, Base64Encode) {
+		ASSERT_EQ("MQ==", base::encode<alphabet::base64>("1"));
+		ASSERT_EQ("MTI=", base::encode<alphabet::base64>("12"));
+		ASSERT_EQ("MTIz", base::encode<alphabet::base64>("123"));
+		ASSERT_EQ("MTIzNA==", base::encode<alphabet::base64>("1234"));
+	}
 
-TEST(BaseTest, Base64Trim) {
-	ASSERT_EQ("MQ", jwt::base::trim<jwt::alphabet::base64>("MQ=="));
-	ASSERT_EQ("MTI", jwt::base::trim<jwt::alphabet::base64>("MTI="));
-	ASSERT_EQ("MTIz", jwt::base::trim<jwt::alphabet::base64>("MTIz"));
-	ASSERT_EQ("MTIzNA", jwt::base::trim<jwt::alphabet::base64>("MTIzNA=="));
-}
+	TEST(BaseTest, Base64EncodeURL) {
+		ASSERT_EQ("MQ%3d%3d", base::encode<alphabet::base64url>("1"));
+		ASSERT_EQ("MTI%3d", base::encode<alphabet::base64url>("12"));
+		ASSERT_EQ("MTIz", base::encode<alphabet::base64url>("123"));
+		ASSERT_EQ("MTIzNA%3d%3d", base::encode<alphabet::base64url>("1234"));
+	}
 
-TEST(BaseTest, Base64TrimURL) {
-	ASSERT_EQ("MQ", jwt::base::trim<jwt::alphabet::base64url>("MQ%3d%3d"));
-	ASSERT_EQ("MTI", jwt::base::trim<jwt::alphabet::base64url>("MTI%3d"));
-	ASSERT_EQ("MTIz", jwt::base::trim<jwt::alphabet::base64url>("MTIz"));
-	ASSERT_EQ("MTIzNA", jwt::base::trim<jwt::alphabet::base64url>("MTIzNA%3d%3d"));
-}
+	TEST(BaseTest, Base64Pad) {
+		ASSERT_EQ("MQ==", base::pad<alphabet::base64>("MQ"));
+		ASSERT_EQ("MTI=", base::pad<alphabet::base64>("MTI"));
+		ASSERT_EQ("MTIz", base::pad<alphabet::base64>("MTIz"));
+		ASSERT_EQ("MTIzNA==", base::pad<alphabet::base64>("MTIzNA"));
+	}
+
+	TEST(BaseTest, Base64PadURL) {
+		ASSERT_EQ("MQ%3d%3d", base::pad<alphabet::base64url>("MQ"));
+		ASSERT_EQ("MTI%3d", base::pad<alphabet::base64url>("MTI"));
+		ASSERT_EQ("MTIz", base::pad<alphabet::base64url>("MTIz"));
+		ASSERT_EQ("MTIzNA%3d%3d", base::pad<alphabet::base64url>("MTIzNA"));
+	}
+
+	TEST(BaseTest, Base64Trim) {
+		ASSERT_EQ("MQ", base::trim<alphabet::base64>("MQ=="));
+		ASSERT_EQ("MTI", base::trim<alphabet::base64>("MTI="));
+		ASSERT_EQ("MTIz", base::trim<alphabet::base64>("MTIz"));
+		ASSERT_EQ("MTIzNA", base::trim<alphabet::base64>("MTIzNA=="));
+	}
+
+	TEST(BaseTest, Base64TrimURL) {
+		ASSERT_EQ("MQ", base::trim<alphabet::base64url>("MQ%3d%3d"));
+		ASSERT_EQ("MTI", base::trim<alphabet::base64url>("MTI%3d"));
+		ASSERT_EQ("MTIz", base::trim<alphabet::base64url>("MTIz"));
+		ASSERT_EQ("MTIzNA", base::trim<alphabet::base64url>("MTIzNA%3d%3d"));
+	}
+} // namespace jwt

--- a/tests/ClaimTest.cpp
+++ b/tests/ClaimTest.cpp
@@ -139,3 +139,37 @@ TEST(ClaimTest, MapOfClaim) {
 	ASSERT_EQ(claims.get_claim("bool").as_boolean(), true);
 	ASSERT_THROW(claims.get_claim("__missing__"), jwt::error::claim_not_present_exception);
 }
+
+#ifdef JWT_HAS_STRING_VIEW
+TEST(ClaimTest, StringViewSupport) {
+	// Force all parameters to be string_views
+	std::string_view jwtType = "JWT";
+	std::string_view claimKey = "access_key";
+	std::string_view claimPayload = "accessKeyPayload";
+	std::string_view alg = "hs512";
+	std::string_view contentType = "mycontent";
+	std::string_view keyId = "mykeyid";
+	std::string_view issuer = "myissuer";
+	std::string_view subject = "mysubject";
+	std::string_view audience = "myaudience";
+	std::string_view id = "myid";
+
+	auto jsonWebToken = jwt::create()
+							.set_algorithm(alg)
+							.set_type(jwtType)
+							.set_content_type(contentType)
+							.set_key_id(keyId)
+							.set_issuer(issuer)
+							.set_subject(subject)
+							.set_audience(audience)
+							.set_id(id)
+							.set_payload_claim(claimKey, jwt::claim(claimPayload));
+
+	std::string_view privateKey = "myprivatekey";
+
+	auto token = jsonWebToken.sign(jwt::algorithm::hs256{privateKey});
+	ASSERT_EQ(token, "eyJhbGciOiJoczUxMiIsImN0eSI6Im15Y29udGVudCIsImtpZCI6Im15a2V5aWQiLCJ0eXAiOiJKV1QifQ."
+					 "eyJhY2Nlc3Nfa2V5IjoiYWNjZXNzS2V5UGF5bG9hZCIsImF1ZCI6Im15YXVkaWVuY2UiLCJpc3MiOiJteWlzc3VlciIsImp0a"
+					 "SI6Im15aWQiLCJzdWIiOiJteXN1YmplY3QifQ.9fd56G-dAxHh89Dl7wZftwsoSfFO_msUFYvA5q77fes");
+}
+#endif

--- a/tests/TokenTest.cpp
+++ b/tests/TokenTest.cpp
@@ -119,6 +119,7 @@ TEST(TokenTest, CreateTokenES256) {
 }
 
 TEST(TokenTest, CreateTokenES256NoPrivate) {
+
 	ASSERT_THROW(
 		[]() {
 			auto token = jwt::create().set_issuer("auth0").set_type("JWS").sign(


### PR DESCRIPTION
If the json library supports `std::string_view`, allow `jwt-cpp` take builder parameters as `std::string_view` and algorithm constructors as well.

Also small optimizations in some methods of `jwt.h` to make sure only one object is returned so that RVO can be used.

PR is ready for review. Only the coverage is failing, I will check why.