### PR TITLE
Fix build with GCC 13

### DIFF
--- a/include/jwt-cpp/base.h
+++ b/include/jwt-cpp/base.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
The header uses fixed-width integer types such as uint32_t but does not include <cstdint>.

The build failed with

    [8/11] Building CXX object example/traits/CMakeFiles/boost-json.dir/boost-json.cpp.o
    FAILED: example/traits/CMakeFiles/boost-json.dir/boost-json.cpp.o
    /usr/bin/c++ -DBOOST_JSON_STANDALONE -I/path/to/src/jwt_cpp/include  -MD -MT example/traits/CMakeFiles/boost-json.dir/boost-json.cpp.o -MF example/traits/CMakeFiles/boost-json.dir/boost-json.cpp.o.d -o example/traits/CMakeFiles/boost-json.dir/boost-json.cpp.o -c /path/to/src/jwt_cpp/example/traits/boost-json.cpp
    In file included from /path/to/src/jwt_cpp/include/jwt-cpp/jwt.h:12,
                        from /path/to/src/jwt_cpp/include/jwt-cpp/traits/boost-json/traits.h:5,
                        from /path/to/src/jwt_cpp/example/traits/boost-json.cpp:1:
    /path/to/src/jwt_cpp/include/jwt-cpp/base.h:91:24: error: ‘uint32_t’ does not name a type
        91 |                 inline uint32_t index(const std::array<char, 64>& alphabet, char symbol) {
            |                        ^~~~~~~~
    /path/to/src/jwt_cpp/include/jwt-cpp/base.h:9:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
        8 | #include <vector>
        +++ |+#include <cstdint>
        9 |

with

    gcc (GCC) 13.0.1 20230401 (Red Hat 13.0.1-0)
    Copyright (C) 2023 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

on Fedora 38.