### PR TITLE
Fix compiler warning (clang, cxx17)

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -3017,11 +3017,32 @@ namespace jwt {
 
 			static std::string to_lower_unicode(const std::string& str, const std::locale& loc) {
 #if __cplusplus > 201103L
-				std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> conv;
-				auto wide = conv.from_bytes(str);
+				std::mbstate_t state = std::mbstate_t();
+				const char* in_next = str.data();
+				const char* in_end = str.data() + str.size();
+				std::wstring wide;
+
+				while (in_next != in_end) {
+					wchar_t wc;
+					std::size_t result = std::mbrtowc(&wc, in_next, in_end - in_next, &state);
+					if (result == static_cast<std::size_t>(-1) || result == static_cast<std::size_t>(-2))
+						break; // conversion error
+					in_next += result;
+					wide.push_back(wc);
+				}
+
 				auto& f = std::use_facet<std::ctype<wchar_t>>(loc);
 				f.tolower(&wide[0], &wide[0] + wide.size());
-				return conv.to_bytes(wide);
+
+				std::string out;
+				for (wchar_t wc : wide) {
+					char mb[MB_CUR_MAX];
+					std::size_t n = std::wcrtomb(mb, wc, &state);
+					if (n != static_cast<std::size_t>(-1))
+						out.append(mb, n);
+				}
+
+				return out;
 #else
 				std::string result;
 				std::transform(str.begin(), str.end(), std::back_inserter(result),


### PR DESCRIPTION
warnings: 

`'wstring_convert<std::codecvt_utf8<wchar_t, 1114111, 0>>' is deprecated` 
`'wstring_convert<std::codecvt_utf8<wchar_t, 1114111, 0>>' has been explicitly marked deprecated here`