### PR TITLE
Fix warning vla-extension by changing MB_CUR_MAX into MB_LEN_MAX which is a compile time constant

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <climits>
 #include <cmath>
 #include <cstring>
 #include <functional>
@@ -3042,7 +3043,7 @@ namespace jwt {
 				std::string out;
 				out.reserve(wide.size());
 				for (wchar_t wc : wide) {
-					char mb[MB_CUR_MAX];
+					char mb[MB_LEN_MAX];
 					std::size_t n = std::wcrtomb(mb, wc, &state);
 					if (n != static_cast<std::size_t>(-1)) out.append(mb, n);
 				}


### PR DESCRIPTION
Latest `jwt-cpp` code produces following warning with `-Wvla-extension`:

```
jwt-cpp-src/include/jwt-cpp/jwt.h:3045:14: warning: variable length arrays are a C99 feature [-Wvla-extension]
                                        char mb[MB_CUR_MAX];
                                                ^~~~~~~~~~
/usr/include/stdlib.h:97:20: note: expanded from macro 'MB_CUR_MAX'
#define MB_CUR_MAX      (__ctype_get_mb_cur_max ())
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
jwt-cpp-src/include/jwt-cpp/jwt.h:3045:14: note: non-constexpr function '__ctype_get_mb_cur_max' cannot be used in a constant expression
/usr/include/stdlib.h:97:21: note: expanded from macro 'MB_CUR_MAX'
#define MB_CUR_MAX      (__ctype_get_mb_cur_max ())
                         ^
/usr/include/stdlib.h:98:15: note: declared here
extern size_t __ctype_get_mb_cur_max (void) __THROW __wur;
              ^
1 warning generated.
```

The easiest way to fix it is to use `MB_LEN_MAX` instead of `MB_CUR_MAX` which is a rather low value anyway (16), and a compile time constant.

According to the [documentation](https://man7.org/linux/man-pages/man3/MB_CUR_MAX.3.html), `MB_CUR_MAX` maximum value (for all locales) is `MB_LEN_MAX`.