### PR TITLE
Fix gcc 12 compiling error

### DIFF
--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -43,3 +43,32 @@ jobs:
         run: |
           CC=gcc-4.8 CXX=g++-4.8 cmake . -DTEST:STRING="defaults-enabled"
           cmake --build .
+
+  gcc-12:
+    runs-on: ubuntu-22.04
+    env:
+      CC: /usr/bin/gcc-12
+      CXX: /usr/bin/g++-12
+    steps:
+      - run: |
+          apt-get update
+          apt-get install -y g++-12 wget make libssl-dev
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install/cmake
+        with:
+          version: "3.26.3"
+          url: "https://cmake.org/files/v3.26/cmake-3.26.3.tar.gz"
+      - uses: ./.github/actions/install/gtest
+
+      - name: setup
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --install .
+
+      - name: test
+        working-directory: tests/cmake
+        run: |
+          CC=gcc-12 CXX=g++-12 cmake . -DTEST:STRING="defaults-enabled"
+          cmake --build .

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -18,7 +18,7 @@ jobs:
     name: GCC 4.8
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:18.04
+      image: ubuntu:bionic-20230530 # 18.04
     env:
       CC: /usr/bin/gcc-4.8
       CXX: /usr/bin/g++-4.8
@@ -45,7 +45,9 @@ jobs:
           cmake --build .
 
   gcc-12:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:jammy-20231004 # 22.04 
     env:
       CC: /usr/bin/gcc-12
       CXX: /usr/bin/g++-12

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           version: "3.26.3"
           url: "https://cmake.org/files/v3.26/cmake-3.26.3.tar.gz"
-      - uses: ./.github/actions/install/gtest
 
       - name: setup
         run: |
@@ -72,5 +71,5 @@ jobs:
       - name: test
         working-directory: tests/cmake
         run: |
-          CC=gcc-12 CXX=g++-12 cmake . -DTEST:STRING="defaults-enabled"
+          CC=gcc-12 CXX=g++-12 cmake . -DCMAKE_CXX_STANDARD=20 -DTEST:STRING="defaults-enabled"
           cmake --build .

--- a/include/jwt-cpp/base.h
+++ b/include/jwt-cpp/base.h
@@ -82,8 +82,8 @@ namespace jwt {
 						 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'}};
 					return data;
 				}
-				static const std::initializer_list<std::string>& fill() {
-					static std::initializer_list<std::string> fill{"%3D", "%3d"};
+				static const std::array<std::string, 2>& fill() {
+					static const std::array<std::string, 2> fill{"%3D", "%3d"};
 					return fill;
 				}
 			};

--- a/include/jwt-cpp/base.h
+++ b/include/jwt-cpp/base.h
@@ -39,7 +39,7 @@ namespace jwt {
 				return data;
 			}
 			static const std::string& fill() {
-				static std::string fill{"="};
+				static const std::string fill{"="};
 				return fill;
 			}
 		};
@@ -62,7 +62,7 @@ namespace jwt {
 				return data;
 			}
 			static const std::string& fill() {
-				static std::string fill{"%3d"};
+				static const std::string fill{"%3d"};
 				return fill;
 			}
 		};
@@ -82,8 +82,8 @@ namespace jwt {
 						 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'}};
 					return data;
 				}
-				static const std::array<std::string, 2>& fill() {
-					static const std::array<std::string, 2> fill{"%3D", "%3d"};
+				static const std::vector<std::string>& fill() {
+					static const std::vector<std::string> fill{"%3D", "%3d"};
 					return fill;
 				}
 			};


### PR DESCRIPTION
With gcc 12, `jwt-cpp` does not compile:
```
[build] include/jwt-cpp/base.h: In static member function ‘static const std::initializer_list<std::__cxx11::basic_string<char> >& jwt::alphabet::helper::base64url_percent_encoding::fill()’:
[build] include/jwt-cpp/base.h:86:100: error: ‘(((const std::__cxx11::basic_string<char>*)(& <temporary>)) != 0)’ is not a constant expression
[build]    86 |                                         static std::initializer_list<std::string> fill{"%3D", "%3d"};
```

However [my other PR](https://github.com/Thalhammer/jwt-cpp/pull/275) fixes the issue much more properly.