### PR TITLE
Build examples only if master project by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,14 @@ endif()
 
 project(jwt-cpp)
 
-option(JWT_BUILD_EXAMPLES "Configure CMake to build examples (or not)" ON)
+# Determine if this is built as a subproject (using add_subdirectory)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(JWT_MASTER_PROJECT ON)
+else()
+  set(JWT_MASTER_PROJECT OFF)
+endif()
+
+option(JWT_BUILD_EXAMPLES "Configure CMake to build examples (or not)" ${JWT_MASTER_PROJECT})
 option(JWT_BUILD_TESTS "Configure CMake to build tests (or not)" OFF)
 option(JWT_ENABLE_COVERAGE "Enable code coverage testing" OFF)
 option(JWT_ENABLE_FUZZING "Enable fuzz testing" OFF)


### PR DESCRIPTION
Hi there!

I changed the default value of JWT_BUILD_EXAMPLES to true iff jwt is the main project.

We are using jwt-cpp as a submodule, and although we have manually disabled this option, it is strange to build examples in a case with a submodule where this is not explicitly set.

What do you think?