### PR TITLE
Add set_expires_in and set_issued_now methods

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -38,8 +38,8 @@ Here is a simple example of creating a token that will expire in one hour:
 
 ```cpp
 auto token = jwt::create()
-    .set_issued_at(std::chrono::system_clock::now())
-    .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{3600})
+	.set_issued_now()
+	.set_expires_in(std::chrono::seconds{3600})
     .sign(jwt::algorithm::hs256{"secret"});
 ```
 

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -38,9 +38,9 @@ Here is a simple example of creating a token that will expire in one hour:
 
 ```cpp
 auto token = jwt::create()
-	.set_issued_now()
-	.set_expires_in(std::chrono::seconds{3600})
-    .sign(jwt::algorithm::hs256{"secret"});
+                .set_issued_now()
+                .set_expires_in(std::chrono::seconds{3600})
+                .sign(jwt::algorithm::hs256{"secret"});
 ```
 
 ### Can you add claims to a signed token?

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -27,8 +27,8 @@ Then everything else is the same, just pass in your implementation such as:
 ```cpp
 auto token = jwt::create()
                 .set_id("custom-algo-example")
-                .set_issued_at(std::chrono::system_clock::now())
-                .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{36000})
+				.set_issued_now()
+				.set_expires_in(std::chrono::seconds{36000})
                 .set_payload_claim("sample", jwt::claim(std::string{"test"}))
                 .sign(your_algorithm{/* what ever you want */});
 ```

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -27,8 +27,8 @@ Then everything else is the same, just pass in your implementation such as:
 ```cpp
 auto token = jwt::create()
                 .set_id("custom-algo-example")
-				.set_issued_now()
-				.set_expires_in(std::chrono::seconds{36000})
+                .set_issued_now()
+                .set_expires_in(std::chrono::seconds{36000})
                 .set_payload_claim("sample", jwt::claim(std::string{"test"}))
                 .sign(your_algorithm{/* what ever you want */});
 ```

--- a/example/es256k.cpp
+++ b/example/es256k.cpp
@@ -18,8 +18,8 @@ K9EDZi0mZ7VUeeNKq476CU5X940yusahgneePQrDMF2nWFEtBCOiXQ==
 					 .set_issuer("auth0")
 					 .set_type("JWT")
 					 .set_id("es256k-create-example")
-					 .set_issued_at(std::chrono::system_clock::now())
-					 .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{36000})
+					 .set_issued_now()
+					 .set_expires_in(std::chrono::seconds{36000})
 					 .set_payload_claim("sample", jwt::claim(std::string{"test"}))
 					 .sign(jwt::algorithm::es256k(es256k_pub_key, es256k_priv_key, "", ""));
 

--- a/example/partial-claim-verifier.cpp
+++ b/example/partial-claim-verifier.cpp
@@ -38,8 +38,8 @@ rK0/Ikt5ybqUzKCMJZg2VKGTxg==
 					 .set_issuer("auth0")
 					 .set_type("JWT")
 					 .set_id("rsa-create-example")
-					 .set_issued_at(std::chrono::system_clock::now())
-					 .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{36000})
+					 .set_issued_now()
+					 .set_expires_in(std::chrono::seconds{36000})
 					 .set_payload_claim("resource-access", role_claim)
 					 .sign(jwt::algorithm::rs256("", rsa_priv_key, "", ""));
 

--- a/example/rsa-create.cpp
+++ b/example/rsa-create.cpp
@@ -35,8 +35,8 @@ rK0/Ikt5ybqUzKCMJZg2VKGTxg==
 					 .set_issuer("auth0")
 					 .set_type("JWT")
 					 .set_id("rsa-create-example")
-					 .set_issued_at(std::chrono::system_clock::now())
-					 .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{36000})
+					 .set_issued_now()
+					 .set_expires_in(std::chrono::seconds{36000})
 					 .set_payload_claim("sample", jwt::claim(std::string{"test"}))
 					 .sign(jwt::algorithm::rs256("", rsa_priv_key, "", ""));
 

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2744,6 +2744,19 @@ namespace jwt {
 		 */
 		builder& set_expires_at(const date& d) { return set_payload_claim("exp", basic_claim<json_traits>(d)); }
 		/**
+		 * Set expires at claim to @p d after the issued at claim
+		 * MUST be called after set_issued_at or set_issued_now
+		 * \param d token expiration timeout
+		 * \return *this to allow for method chaining
+         * \throw std::runtime_error If issued at claim was not present
+         * \throw std::bad_cast Claim was present but not a date (Should not happen in a valid token)
+		 */
+		template<class Rep>
+		builder& set_expires_in(const std::chrono::duration<Rep>& d) {
+			date iat = payload_claims["iat"].as_date();
+			return set_payload_claim("exp", basic_claim<json_traits>(iat + d));
+		}
+		/**
 		 * Set not before claim
 		 * \param d First valid time
 		 * \return *this to allow for method chaining
@@ -2755,6 +2768,11 @@ namespace jwt {
 		 * \return *this to allow for method chaining
 		 */
 		builder& set_issued_at(const date& d) { return set_payload_claim("iat", basic_claim<json_traits>(d)); }
+		/**
+		 * Set issued at claim to current time, as determined by std::chrono::system_clock::now()
+		 * \return *this to allow for method chaining
+		 */
+		builder& set_issued_now() { return set_issued_at(std::chrono::system_clock::now()); }
 		/**
 		 * Set id claim
 		 * \param str ID to set

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2622,13 +2622,19 @@ namespace jwt {
 	 * Builder class to build and sign a new token
 	 * Use jwt::create() to get an instance of this class.
 	 */
-	template<typename json_traits>
+	template<typename Clock, typename json_traits>
 	class builder {
 		typename json_traits::object_type header_claims;
 		typename json_traits::object_type payload_claims;
 
+		/// Instance of clock type
+		Clock clock;
 	public:
-		builder() = default;
+		/**
+		 * Constructor for building a new builder instance
+		 * \param c Clock instance
+		 */
+		explicit builder(Clock c) : clock(c) {}
 		/**
 		 * Set a header claim.
 		 * \param id Name of the claim
@@ -2772,7 +2778,7 @@ namespace jwt {
 		 * Set issued at claim to current time, as determined by std::chrono::system_clock::now()
 		 * \return *this to allow for method chaining
 		 */
-		builder& set_issued_now() { return set_issued_at(std::chrono::system_clock::now()); }
+		builder& set_issued_now() { return set_issued_at(clock.now()); }
 		/**
 		 * Set id claim
 		 * \param str ID to set
@@ -3608,8 +3614,8 @@ namespace jwt {
 	 * Return a builder instance to create a new token
 	 */
 	template<typename json_traits>
-	builder<json_traits> create() {
-		return builder<json_traits>();
+	builder<default_clock, json_traits> create(default_clock c = {}) {
+		return builder<default_clock, json_traits>(c);
 	}
 
 	/**

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -3590,6 +3590,16 @@ namespace jwt {
 	}
 
 	/**
+	 * Create a builder using the given clock
+	 * \param c Clock instance to use
+	 * \return builder instance
+	 */
+	template<typename Clock, typename json_traits>
+	builder<Clock, json_traits> create(Clock c) {
+		return builder<Clock, json_traits>(c);
+	}
+
+	/**
 	 * Default clock class using std::chrono::system_clock as a backend.
 	 */
 	struct default_clock {

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2634,7 +2634,7 @@ namespace jwt {
 		 * Constructor for building a new builder instance
 		 * \param c Clock instance
 		 */
-		explicit builder(Clock c) : clock(c) {}
+		JWT_CLAIM_EXPLICIT builder(Clock c) : clock(c) {}
 		/**
 		 * Set a header claim.
 		 * \param id Name of the claim

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2629,6 +2629,7 @@ namespace jwt {
 
 		/// Instance of clock type
 		Clock clock;
+
 	public:
 		/**
 		 * Constructor for building a new builder instance

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2750,17 +2750,13 @@ namespace jwt {
 		 */
 		builder& set_expires_at(const date& d) { return set_payload_claim("exp", basic_claim<json_traits>(d)); }
 		/**
-		 * Set expires at claim to @p d after the issued at claim
-		 * MUST be called after set_issued_at or set_issued_now
+		 * Set expires at claim to @p d from the current moment
 		 * \param d token expiration timeout
 		 * \return *this to allow for method chaining
-         * \throw std::runtime_error If issued at claim was not present
-         * \throw std::bad_cast Claim was present but not a date (Should not happen in a valid token)
 		 */
 		template<class Rep>
 		builder& set_expires_in(const std::chrono::duration<Rep>& d) {
-			date iat = payload_claims["iat"].as_date();
-			return set_payload_claim("exp", basic_claim<json_traits>(iat + d));
+			return set_payload_claim("exp", basic_claim<json_traits>(clock.now() + d));
 		}
 		/**
 		 * Set not before claim
@@ -2775,7 +2771,7 @@ namespace jwt {
 		 */
 		builder& set_issued_at(const date& d) { return set_payload_claim("iat", basic_claim<json_traits>(d)); }
 		/**
-		 * Set issued at claim to current time, as determined by std::chrono::system_clock::now()
+		 * Set issued at claim to the current moment
 		 * \return *this to allow for method chaining
 		 */
 		builder& set_issued_now() { return set_issued_at(clock.now()); }

--- a/include/jwt-cpp/traits/boost-json/defaults.h
+++ b/include/jwt-cpp/traits/boost-json/defaults.h
@@ -25,9 +25,12 @@ namespace jwt {
 	}
 
 	/**
-	 * Return a builder instance to create a new token
+	 * Create a builder using the default clock
+	 * \return builder instance to create a new token
 	 */
-	inline builder<traits::boost_json> create() { return builder<traits::boost_json>(); }
+	inline builder<default_clock, traits::boost_json> create() {
+		return builder<default_clock, traits::boost_json>(default_clock{});
+	}
 
 #ifndef JWT_DISABLE_BASE64
 	/**

--- a/include/jwt-cpp/traits/danielaparker-jsoncons/defaults.h
+++ b/include/jwt-cpp/traits/danielaparker-jsoncons/defaults.h
@@ -25,9 +25,12 @@ namespace jwt {
 	}
 
 	/**
-	 * Return a builder instance to create a new token
+	 * Create a builder using the default clock
+	 * \return builder instance to create a new token
 	 */
-	inline builder<traits::danielaparker_jsoncons> create() { return builder<traits::danielaparker_jsoncons>(); }
+	inline builder<default_clock, traits::danielaparker_jsoncons> create() {
+		return builder<default_clock, traits::danielaparker_jsoncons>(default_clock{});
+	}
 
 #ifndef JWT_DISABLE_BASE64
 	/**

--- a/include/jwt-cpp/traits/defaults.h.mustache
+++ b/include/jwt-cpp/traits/defaults.h.mustache
@@ -28,10 +28,10 @@ namespace jwt {
 
 	/**
 	 * Create a builder using the default clock
-	 * \return builder instance
+	 * \return builder instance to create a new token
 	 */
 	inline builder<default_clock, traits::{{traits_name}}> create() {
-		return builder<default_clock, traits::{{traits_name}}>();
+		return builder<default_clock, traits::{{traits_name}}>(default_clock{});
 	}
 
 #ifndef JWT_DISABLE_BASE64

--- a/include/jwt-cpp/traits/defaults.h.mustache
+++ b/include/jwt-cpp/traits/defaults.h.mustache
@@ -27,9 +27,12 @@ namespace jwt {
 	}
 
 	/**
-	 * Return a builder instance to create a new token
+	 * Create a builder using the default clock
+	 * \return builder instance
 	 */
-	inline builder<traits::{{traits_name}}> create() { return builder<traits::{{traits_name}}>(); }
+	inline builder<default_clock, traits::{{traits_name}}> create() {
+		return builder<default_clock, traits::{{traits_name}}>();
+	}
 
 #ifndef JWT_DISABLE_BASE64
 	/**

--- a/include/jwt-cpp/traits/kazuho-picojson/defaults.h
+++ b/include/jwt-cpp/traits/kazuho-picojson/defaults.h
@@ -21,9 +21,12 @@ namespace jwt {
 	}
 
 	/**
-	 * Return a builder instance to create a new token
+	 * Create a builder using the default clock
+	 * \return builder instance to create a new token
 	 */
-	inline builder<traits::kazuho_picojson> create() { return builder<traits::kazuho_picojson>(); }
+	inline builder<default_clock, traits::kazuho_picojson> create() {
+		return builder<default_clock, traits::kazuho_picojson>(default_clock{});
+	}
 
 #ifndef JWT_DISABLE_BASE64
 	/**

--- a/include/jwt-cpp/traits/nlohmann-json/defaults.h
+++ b/include/jwt-cpp/traits/nlohmann-json/defaults.h
@@ -25,9 +25,12 @@ namespace jwt {
 	}
 
 	/**
-	 * Return a builder instance to create a new token
+	 * Create a builder using the default clock
+	 * \return builder instance to create a new token
 	 */
-	inline builder<traits::nlohmann_json> create() { return builder<traits::nlohmann_json>(); }
+	inline builder<default_clock, traits::nlohmann_json> create() {
+		return builder<default_clock, traits::nlohmann_json>(default_clock{});
+	}
 
 #ifndef JWT_DISABLE_BASE64
 	/**

--- a/include/jwt-cpp/traits/open-source-parsers-jsoncpp/defaults.h
+++ b/include/jwt-cpp/traits/open-source-parsers-jsoncpp/defaults.h
@@ -25,10 +25,11 @@ namespace jwt {
 	}
 
 	/**
-	 * Return a builder instance to create a new token
+	 * Create a builder using the default clock
+	 * \return builder instance to create a new token
 	 */
-	inline builder<traits::open_source_parsers_jsoncpp> create() {
-		return builder<traits::open_source_parsers_jsoncpp>();
+	inline builder<default_clock, traits::open_source_parsers_jsoncpp> create() {
+		return builder<default_clock, traits::open_source_parsers_jsoncpp>(default_clock{});
 	}
 
 #ifndef JWT_DISABLE_BASE64

--- a/tests/traits/BoostJsonTest.cpp
+++ b/tests/traits/BoostJsonTest.cpp
@@ -83,6 +83,19 @@ TEST(BoostJsonTest, VerifyTokenExpirationValid) {
 	verify.verify(decoded_token);
 }
 
+TEST(BoostJsonTest, VerifyTokenExpirationInValid) {
+	const auto token = jwt::create<jwt::traits::boost_json>()
+						   .set_issuer("auth0")
+						   .set_issued_now()
+						   .set_expires_in(std::chrono::seconds{3600})
+						   .sign(jwt::algorithm::hs256{"secret"});
+
+	const auto decoded_token = jwt::decode<jwt::traits::boost_json>(token);
+	const auto verify =
+		jwt::verify<jwt::traits::boost_json>().allow_algorithm(jwt::algorithm::hs256{"secret"}).with_issuer("auth0");
+	verify.verify(decoded_token);
+}
+
 TEST(BoostJsonTest, VerifyTokenExpired) {
 	const auto token = jwt::create<jwt::traits::boost_json>()
 						   .set_issuer("auth0")

--- a/tests/traits/JsonconsTest.cpp
+++ b/tests/traits/JsonconsTest.cpp
@@ -86,6 +86,20 @@ TEST(JsonconsTest, VerifyTokenExpirationValid) {
 	verify.verify(decoded_token);
 }
 
+TEST(JsonconsTest, VerifyTokenExpirationInValid) {
+	const auto token = jwt::create<jwt::traits::danielaparker_jsoncons>()
+						   .set_issuer("auth0")
+						   .set_issued_now()
+						   .set_expires_in(std::chrono::seconds{3600})
+						   .sign(jwt::algorithm::hs256{"secret"});
+
+	const auto decoded_token = jwt::decode<jwt::traits::danielaparker_jsoncons>(token);
+	const auto verify = jwt::verify<jwt::traits::danielaparker_jsoncons>()
+							.allow_algorithm(jwt::algorithm::hs256{"secret"})
+							.with_issuer("auth0");
+	verify.verify(decoded_token);
+}
+
 TEST(JsonconsTest, VerifyTokenExpired) {
 	const auto token = jwt::create<jwt::traits::danielaparker_jsoncons>()
 						   .set_issuer("auth0")

--- a/tests/traits/NlohmannTest.cpp
+++ b/tests/traits/NlohmannTest.cpp
@@ -82,6 +82,19 @@ TEST(NlohmannTest, VerifyTokenExpirationValid) {
 	verify.verify(decoded_token);
 }
 
+TEST(NlohmannTest, VerifyTokenExpirationInValid) {
+	const auto token = jwt::create<jwt::traits::nlohmann_json>()
+						   .set_issuer("auth0")
+						   .set_issued_now()
+						   .set_expires_in(std::chrono::seconds{3600})
+						   .sign(jwt::algorithm::hs256{"secret"});
+
+	const auto decoded_token = jwt::decode<jwt::traits::nlohmann_json>(token);
+	const auto verify =
+		jwt::verify<jwt::traits::nlohmann_json>().allow_algorithm(jwt::algorithm::hs256{"secret"}).with_issuer("auth0");
+	verify.verify(decoded_token);
+}
+
 TEST(NlohmannTest, VerifyTokenExpired) {
 	const auto token = jwt::create<jwt::traits::nlohmann_json>()
 						   .set_issuer("auth0")

--- a/tests/traits/OspJsoncppTest.cpp
+++ b/tests/traits/OspJsoncppTest.cpp
@@ -86,6 +86,20 @@ TEST(OspJsoncppTest, VerifyTokenExpirationValid) {
 	verify.verify(decoded_token);
 }
 
+TEST(OspJsoncppTest, VerifyTokenExpirationInValid) {
+	const auto token = jwt::create<jwt::traits::open_source_parsers_jsoncpp>()
+						   .set_issuer("auth0")
+						   .set_issued_now()
+						   .set_expires_in(std::chrono::seconds{3600})
+						   .sign(jwt::algorithm::hs256{"secret"});
+
+	const auto decoded_token = jwt::decode<jwt::traits::open_source_parsers_jsoncpp>(token);
+	const auto verify = jwt::verify<jwt::traits::open_source_parsers_jsoncpp>()
+							.allow_algorithm(jwt::algorithm::hs256{"secret"})
+							.with_issuer("auth0");
+	verify.verify(decoded_token);
+}
+
 TEST(OspJsoncppTest, VerifyTokenExpired) {
 	const auto token = jwt::create<jwt::traits::open_source_parsers_jsoncpp>()
 						   .set_issuer("auth0")

--- a/tests/traits/TraitsTest.cpp.mustache
+++ b/tests/traits/TraitsTest.cpp.mustache
@@ -86,6 +86,20 @@ TEST({{test_suite_name}}, VerifyTokenExpirationValid) {
 	verify.verify(decoded_token);
 }
 
+TEST({{test_suite_name}}, VerifyTokenExpirationInValid) {
+	const auto token = jwt::create<jwt::traits::{{traits_name}}>()
+						   .set_issuer("auth0")
+						   .set_issued_now()
+						   .set_expires_in(std::chrono::seconds{3600})
+						   .sign(jwt::algorithm::hs256{"secret"});
+
+	const auto decoded_token = jwt::decode<jwt::traits::{{traits_name}}>(token);
+	const auto verify = jwt::verify<jwt::traits::{{traits_name}}>()
+							.allow_algorithm(jwt::algorithm::hs256{"secret"})
+							.with_issuer("auth0");
+	verify.verify(decoded_token);
+}
+
 TEST({{test_suite_name}}, VerifyTokenExpired) {
 	const auto token = jwt::create<jwt::traits::{{traits_name}}>()
 						   .set_issuer("auth0")


### PR DESCRIPTION
Hi there!

I added `set_expires_in` and `set_issued_now` method for the jwt builder.

- `set_issued_now` sets a "iat" claim by calling system_clock::now() by itself;
- `set_expires_in` sets a "exp" claim by adding the given duration to ~~the "iat" claim~~ system_clock::now()

Common usage of the jwt builder is:
- create a builder
- set the "iat" claim at the "now" moment
- set the token expiration timeout

This should make it a little bit more convenient.

Update: builder now has the Clock template parameter just like the verifier