### PR TITLE
Use built-in openssl from action's on windows

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -13,9 +13,6 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
-      - if: matrix.os == 'windows-latest'
-        run: choco install openssl
-
       - if: matrix.os == 'macos-latest'
         run: sudo cp /usr/local/opt/openssl@1.1/lib/pkgconfig/*.pc /usr/local/lib/pkgconfig/
 


### PR DESCRIPTION
The required Cross-Platform test broke on Jan 14. 

3.2.0 was added to chocolatey pulling from shinning light products which it's kinda annoying since that's been out for months... it should be in the 2022 runner image https://github.com/actions/runner-images/blob/f046bcaec35305f006ce3cb6fdebb161d0ea5577/images/windows/toolsets/toolset-2022.json#L433

Tested this fix https://github.com/prince-chrismc/jwt-cpp/actions/runs/7550170255 and I will need to figure out a better way to install openssl on windows since this is not very reliable 🤷 😞 