### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,7 +17,7 @@ jobs:
   default-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
       - name: setup
@@ -36,7 +36,7 @@ jobs:
   default-linux-with-examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
       - name: setup
@@ -55,7 +55,7 @@ jobs:
   default-win:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - run: choco install openssl
 
@@ -75,7 +75,7 @@ jobs:
   min-req:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install/cmake
         with:
           version: "3.14.7"
@@ -98,7 +98,7 @@ jobs:
   custom-install-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
       - name: setup
@@ -117,7 +117,7 @@ jobs:
   custom-install-win:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - run: choco install openssl
 
@@ -137,7 +137,7 @@ jobs:
   no-pico:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
       - name: setup
@@ -156,7 +156,7 @@ jobs:
   no-base64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
       - name: setup
@@ -175,7 +175,7 @@ jobs:
   with-libressl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/libressl
 
@@ -195,7 +195,7 @@ jobs:
   with-wolfssl:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/wolfssl
         with:
@@ -217,7 +217,7 @@ jobs:
   with-hunter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
 
       - name: setup

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -19,7 +19,7 @@ jobs:
       - if: matrix.os == 'macos-latest'
         run: sudo cp /usr/local/opt/openssl@1.1/lib/pkgconfig/*.pc /usr/local/lib/pkgconfig/
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cmake -E make_directory ${{ github.workspace }}/build
 
       - name: configure

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ssciwr/doxygen-install@v1
         with:
           version: "1.10.0"

--- a/.github/workflows/jwt.yml
+++ b/.github/workflows/jwt.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: build/coverage.info
-          format: gcov
+          format: lcov
 
   fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/jwt.yml
+++ b/.github/workflows/jwt.yml
@@ -10,7 +10,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
       - uses: ./.github/actions/install/danielaparker-jsoncons
@@ -27,15 +27,15 @@ jobs:
         working-directory: build
         run: make jwt-cpp-test coverage
 
-      - uses: coverallsapp/github-action@1.1.3
+      - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: build/coverage.info
+          file: build/coverage.info
 
   fuzzing:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: lukka/get-cmake@latest
     - uses: ./.github/actions/install/gtest
       
@@ -62,7 +62,7 @@ jobs:
           - { tag: "openssl-3.0.5", name: "3.0.5" }
           - { tag: "OpenSSL_1_1_1q", name: "1.1.1q" }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
       - uses: ./.github/actions/install/openssl
@@ -91,7 +91,7 @@ jobs:
   ubsan:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
 

--- a/.github/workflows/jwt.yml
+++ b/.github/workflows/jwt.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: build/coverage.info
+          format: gcov
 
   fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,7 +66,7 @@ jobs:
           linter_name: clang-tidy
 
   render-defaults:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -95,7 +95,7 @@ jobs:
           linter_name: render-defaults
 
   render-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - run: |
           sudo apt-get install clang-format-14
           shopt -s globstar
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: clang-format-14 -i ${{ matrix.files }}
       - uses: ./.github/actions/process-linting-results
         with:
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.x"
       - run: pip install cmakelang
       - run: shopt -s globstar
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: cmake-format -i ${{ matrix.files }}
       - uses: ./.github/actions/process-linting-results
         with:
@@ -52,7 +52,7 @@ jobs:
     steps:
       - run: sudo apt-get install clang-tidy
       - uses: lukka/get-cmake@latest
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: configure
         run: |
           mkdir build
@@ -78,7 +78,9 @@ jobs:
           - { name: "open_source_parsers_jsoncpp", library: "jsoncpp", url: "https://github.com/open-source-parsers/jsoncpp", disable_pico: true }
     name: render-defaults (${{ matrix.traits.name }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - run: |
+          sudo apt-get install clang-format-14
       - uses: ./.github/actions/render/defaults
         id: render
         with:
@@ -86,7 +88,7 @@ jobs:
           library_name: ${{ matrix.traits.library }}
           library_url: ${{ matrix.traits.url }}
           disable_default_traits: ${{ matrix.traits.disable_pico }}
-      - run: clang-format -i ${{ steps.render.outputs.file_path }}
+      - run: clang-format-14 -i ${{ steps.render.outputs.file_path }}
       - run: git add ${{ steps.render.outputs.file_path }}
       - uses: ./.github/actions/process-linting-results
         with:
@@ -105,13 +107,15 @@ jobs:
           - { name: "open_source_parsers_jsoncpp", suite: "OspJsoncppTest" }
     name: render-tests (${{ matrix.traits.name }})
     steps:
-      - uses: actions/checkout@v3
-      - run: shopt -s globstar
+      - uses: actions/checkout@v4
+      - run: |
+          sudo apt-get install clang-format-14
+          shopt -s globstar
       - uses: ./.github/actions/render/tests
         with:
           traits_name: ${{ matrix.traits.name }}
           test_suite_name: ${{ matrix.traits.suite }}
-      - run: clang-format -i tests/**/*.cpp
+      - run: clang-format-14 -i tests/**/*.cpp
       - run: git add tests/traits/*
       - uses: ./.github/actions/process-linting-results
         with:
@@ -120,7 +124,7 @@ jobs:
   line-ending:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git add --renormalize .
       - uses: ./.github/actions/process-linting-results
         with:

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
         with:

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
         with:

--- a/.github/workflows/ssl.yml
+++ b/.github/workflows/ssl.yml
@@ -19,7 +19,7 @@ jobs:
           - { tag: "OpenSSL_1_0_1u", name: "1.0.1u" }
     name: OpenSSL ${{ matrix.openssl.name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
       - uses: ./.github/actions/install/openssl
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     name: OpenSSL 3.0 No Deprecated
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
       - uses: ./.github/actions/install/openssl
@@ -61,7 +61,7 @@ jobs:
         libressl: ["3.5.3", "3.4.3", "3.3.6"]
     name: LibreSSL ${{ matrix.libressl }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
       - uses: ./.github/actions/install/libressl
@@ -90,7 +90,7 @@ jobs:
           - { ref: "v5.3.0-stable", name: "5.3.0"}
     name: wolfSSL ${{ matrix.wolfssl.name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
       - uses: ./.github/actions/install/wolfssl

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -26,7 +26,7 @@ jobs:
       - run: |
           apt-get update
           apt-get install -y g++-4.8 wget make libssl-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install/cmake
         with:
           version: "3.26.3"
@@ -55,7 +55,7 @@ jobs:
       - run: |
           apt-get update
           apt-get install -y g++-12 wget make libssl-dev
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install/cmake
         with:
           version: "3.26.3"

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -30,7 +30,8 @@ jobs:
 
           echo "Intalling NodeJS 20 for Github Actions..."
           wget https://raw.githubusercontent.com/nodesource/distributions/master/scripts/deb/setup_20.x
-          source setup_20.x
+          chmod +x setup_20.x
+          ./setup_20.x
           apt-get install nodejs
           node -v
       - uses: actions/checkout@v4

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -23,9 +23,16 @@ jobs:
       CC: /usr/bin/gcc-4.8
       CXX: /usr/bin/g++-4.8
     steps:
-      - run: |
+      - working-directory: /tmp
+        run: |
           apt-get update
           apt-get install -y g++-4.8 wget make libssl-dev
+
+          echo "Intalling NodeJS 20 for Github Actions..."
+          wget https://raw.githubusercontent.com/nodesource/distributions/master/scripts/deb/setup_20.x
+          source setup_20.x
+          apt-get install nodejs
+          node -v
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install/cmake
         with:

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -27,14 +27,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y g++-4.8 wget make libssl-dev
-
-          echo "Intalling NodeJS 20 for Github Actions..."
-          wget https://raw.githubusercontent.com/nodesource/distributions/master/scripts/deb/setup_20.x
-          chmod +x setup_20.x
-          ./setup_20.x
-          apt-get install nodejs
-          node -v
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3 # Can not be upgrade as v4 needs NodeJS 20 doesn't exist next to gcc-4.8 
       - uses: ./.github/actions/install/cmake
         with:
           version: "3.26.3"

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -23,8 +23,7 @@ jobs:
       CC: /usr/bin/gcc-4.8
       CXX: /usr/bin/g++-4.8
     steps:
-      - working-directory: /tmp
-        run: |
+      - run: |
           apt-get update
           apt-get install -y g++-4.8 wget make libssl-dev
       - uses: actions/checkout@v3 # Can not be upgrade as v4 needs NodeJS 20 doesn't exist next to gcc-4.8 

--- a/.github/workflows/traits.yml
+++ b/.github/workflows/traits.yml
@@ -19,7 +19,7 @@ jobs:
           - { name: "kazuho-picojson", tag: "111c9be5188f7350c2eac9ddaedd8cca3d7bf394", version: "111c9be" }
           - { name: "open-source-parsers-jsoncpp", tag: "1.9.5", version: "v1.9.5" }
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - name: setup
         run: |


### PR DESCRIPTION
- actions/checkout@v4 for the most part
- pin donw format to clang-14 for all linter jobs
- coverallsapp/github-action@v2 with explicit format