### PR TITLE
Remove unused header

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -37,10 +37,6 @@
 #include <utility>
 #include <vector>
 
-#if __cplusplus > 201103L
-#include <codecvt>
-#endif
-
 #if __cplusplus >= 201402L
 #ifdef __has_include
 #if __has_include(<experimental/type_traits>)


### PR DESCRIPTION
The title tells it all. The codecvt header is no longer used in jwt-cpp therefore there is no reason to keep including it.