### PR TITLE
Fix compiler warning

### DIFF
--- a/include/jwt-cpp/base.h
+++ b/include/jwt-cpp/base.h
@@ -93,7 +93,7 @@ namespace jwt {
 			auto itr = std::find_if(alphabet.cbegin(), alphabet.cend(), [symbol](char c) { return c == symbol; });
 			if (itr == alphabet.cend()) { throw std::runtime_error("Invalid input: not within alphabet"); }
 
-			return std::distance(alphabet.cbegin(), itr);
+			return static_cast<uint32_t>(std::distance(alphabet.cbegin(), itr));
 		}
 	} // namespace alphabet
 


### PR DESCRIPTION
Visual Studio reports "'return': conversion from '__int64' to 'uint32_t', possible loss of data" because it is unable to grok that the answer can't be bigger than the size of the array