### PR TITLE
Support new Action macOS Runners

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -13,7 +13,7 @@ jobs:
         os: [macos-14, windows-latest, ubuntu-latest]
 
     steps:
-      - if: matrix.os == 'macos-latest'
+      - if: matrix.os == 'macos-14'
         run: sudo cp /usr/local/opt/openssl@1.1/lib/pkgconfig/*.pc /usr/local/lib/pkgconfig/
 
       - uses: actions/checkout@v4

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -10,12 +10,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, windows-latest, ubuntu-latest]
+        os: [macos-12, windows-latest, ubuntu-latest]
 
     steps:
-      - if: matrix.os == 'macos-14'
-        run: sudo cp /usr/local/opt/openssl@1.1/lib/pkgconfig/*.pc /usr/local/lib/pkgconfig/
-
       - uses: actions/checkout@v4
       - run: cmake -E make_directory ${{ github.workspace }}/build
 

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-14, windows-latest, ubuntu-latest]
 
     steps:
       - if: matrix.os == 'macos-latest'


### PR DESCRIPTION
Actions are update the Runners, they canary release of macos-14 as latest is causing the workflow to fail... depending on is the repo is in a or b test group.[461162c](https://github.com/Thalhammer/jwt-cpp/commit/461162ca7938ecee8f93e4b7ed8a0927802c554c) found this

This simply removes an old workaround that it not required anymore. Currently Linux is using 3.0.2 from ubuntu-22, macos will be ahead with 3.3.0 and windows is on 1.1.1w (we can update to 3.x with choco which is available)

### MacOS latest 

- Old Behavoir
  ```
  -- Found OpenSSL: /usr/local/Cellar/openssl@1.1/1.1.1w/lib/libcrypto.dylib (found suitable version "1.1.1w", minimum required is "1.0.1")
  ```

- macos-14 no workaround
  ```
  -- Found OpenSSL: /opt/homebrew/Cellar/openssl@3/3.2.1/lib/libcrypto.dylib (found suitable version "3.2.1", minimum required is "1.0.1")
  ```
- macos-12 no workaround
  ```
  -- Found OpenSSL: /usr/local/Cellar/openssl@3/3.2.1/lib/libcrypto.dylib (found suitable version "3.2.1", minimum required is "1.0.1")
  ```