### PR TITLE
Disable gcc-4.8 since node20 is now required

### DIFF
--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   gcc-4-8:
+    if: false # There's no existing image with node20 and gcc4.8 https://github.com/actions/checkout/issues/1809
     name: GCC 4.8
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
I noticed this on https://github.com/prince-chrismc/jwt-cpp/actions/runs/9846197486/job/27183454214?pr=38.
GitHub has been slowing pushing everything off of node16 since it's been EOL'd, the latest runner version now overrides even older actions that were not updated. I've only found documentation for self-hosted runners https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ which sadly doesn't appear to work. I have been playing with supporting this compiler on newer platforms but it's a lot of work https://github.com/prince-chrismc/jwt-cpp/pull/46 🤞 