### PR TITLE
Jsoncpp traits no longer uses deprecated Reader

### DIFF
--- a/include/jwt-cpp/traits/open-source-parsers-jsoncpp/traits.h
+++ b/include/jwt-cpp/traits/open-source-parsers-jsoncpp/traits.h
@@ -120,10 +120,8 @@ namespace jwt {
 				Json::CharReaderBuilder builder;
 				const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
 
-				return reader->parse(
-					reinterpret_cast<const char*>(str.c_str()),
-					reinterpret_cast<const char*>(str.c_str() + str.size()), &val,
-					nullptr);
+				return reader->parse(reinterpret_cast<const char*>(str.c_str()),
+									 reinterpret_cast<const char*>(str.c_str() + str.size()), &val, nullptr);
 			}
 
 			static string_type serialize(const value_type& val) {

--- a/include/jwt-cpp/traits/open-source-parsers-jsoncpp/traits.h
+++ b/include/jwt-cpp/traits/open-source-parsers-jsoncpp/traits.h
@@ -117,8 +117,13 @@ namespace jwt {
 			}
 
 			static bool parse(value_type& val, string_type str) {
-				Json::Reader reader;
-				return reader.parse(str, val);
+				Json::CharReaderBuilder builder;
+				const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+
+				return reader->parse(
+					reinterpret_cast<const char*>(str.c_str()),
+					reinterpret_cast<const char*>(str.c_str() + str.size()), &val,
+					nullptr);
 			}
 
 			static string_type serialize(const value_type& val) {


### PR DESCRIPTION
The jsoncpp trait made use of the [deprecated Reader](https://github.com/open-source-parsers/jsoncpp/releases/tag/1.4.0).

This PR fixes this. Safer and no more deprecation warnings when compiling.

