### PR TITLE
Support passing ssl library key handles to algorithms

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1570,11 +1570,9 @@ namespace jwt {
 					throw error::ecdsa_exception(error::ecdsa_error::invalid_key_size);
 			}
 
-			ecdsa(helper::evp_pkey_handle private_key, const EVP_MD* (*md)(), std::string name, size_t siglen)
-				: pkey(std::move(private_key)), md(md), alg_name(std::move(name)), signature_length(siglen) {
-				if (pkey) {
-					check_private_key(pkey.get());
-				} else {
+			ecdsa(helper::evp_pkey_handle key_pair, const EVP_MD* (*md)(), std::string name, size_t siglen)
+				: pkey(std::move(key_pair)), md(md), alg_name(std::move(name)), signature_length(siglen) {
+				if (!pkey) {
 					throw error::ecdsa_exception(error::ecdsa_error::no_key_provided);
 				}
 				size_t keysize = EVP_PKEY_bits(pkey.get());

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1461,6 +1461,17 @@ namespace jwt {
 					throw error::rsa_exception(error::rsa_error::no_key_provided);
 			}
 			/**
+			 * Construct new rsa algorithm
+			 *
+			 * \param key_pair openssl EVP_PKEY structure containing RSA key pair. The private part is optional.
+			 * \param md Pointer to hash function
+			 * \param name Name of the algorithm
+			 */
+			rsa(helper::evp_pkey_handle key_pair, const EVP_MD* (*md)(), std::string name)
+				: pkey(std::move(key_pair)), md(md), alg_name(std::move(name)) {
+				if (!pkey) { throw error::rsa_exception(error::rsa_error::no_key_provided); }
+			}
+			/**
 			 * Sign jwt data
 			 * \param data The data to sign
 			 * \param ec error_code filled with details on error

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1591,9 +1591,7 @@ namespace jwt {
 			 */
 			ecdsa(helper::evp_pkey_handle key_pair, const EVP_MD* (*md)(), std::string name, size_t siglen)
 				: pkey(std::move(key_pair)), md(md), alg_name(std::move(name)), signature_length(siglen) {
-				if (!pkey) {
-					throw error::ecdsa_exception(error::ecdsa_error::no_key_provided);
-				}
+				if (!pkey) { throw error::ecdsa_exception(error::ecdsa_error::no_key_provided); }
 				size_t keysize = EVP_PKEY_bits(pkey.get());
 				if (keysize != signature_length * 4 && (signature_length != 132 || keysize != 521))
 					throw error::ecdsa_exception(error::ecdsa_error::invalid_key_size);

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1570,6 +1570,18 @@ namespace jwt {
 					throw error::ecdsa_exception(error::ecdsa_error::invalid_key_size);
 			}
 
+			ecdsa(helper::evp_pkey_handle private_key, const EVP_MD* (*md)(), std::string name, size_t siglen)
+				: pkey(std::move(private_key)), md(md), alg_name(std::move(name)), signature_length(siglen) {
+				if (pkey) {
+					check_private_key(pkey.get());
+				} else {
+					throw error::ecdsa_exception(error::ecdsa_error::no_key_provided);
+				}
+				size_t keysize = EVP_PKEY_bits(pkey.get());
+				if (keysize != signature_length * 4 && (signature_length != 132 || keysize != 521))
+					throw error::ecdsa_exception(error::ecdsa_error::invalid_key_size);
+			}
+
 			/**
 			 * Sign jwt data
 			 * \param data The data to sign

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -1570,6 +1570,14 @@ namespace jwt {
 					throw error::ecdsa_exception(error::ecdsa_error::invalid_key_size);
 			}
 
+			/**
+			 * Construct new ecdsa algorithm
+			 *
+			 * \param key_pair openssl EVP_PKEY structure containing ECDSA key pair. The private part is optional.
+			 * \param md Pointer to hash function
+			 * \param name Name of the algorithm
+			 * \param siglen The bit length of the signature
+			 */
 			ecdsa(helper::evp_pkey_handle key_pair, const EVP_MD* (*md)(), std::string name, size_t siglen)
 				: pkey(std::move(key_pair)), md(md), alg_name(std::move(name)), signature_length(siglen) {
 				if (!pkey) {

--- a/tests/TokenTest.cpp
+++ b/tests/TokenTest.cpp
@@ -71,6 +71,18 @@ TEST(TokenTest, CreateTokenRS256) {
 		token);
 }
 
+TEST(TokenTest, CreateTokenEvpPkeyRS256) {
+	auto token = jwt::create().set_issuer("auth0").set_type("JWS").sign(
+		jwt::algorithm::rsa(jwt::helper::load_private_key_from_string(rsa_priv_key), EVP_sha256, "RS256"));
+
+	ASSERT_EQ(
+		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.VA2i1ui1cnoD6I3wnji1WAVCf29EekysvevGrT2GXqK1dDMc8"
+		"HAZCTQxa1Q8NppnpYV-hlqxh-X3Bb0JOePTGzjynpNZoJh2aHZD-GKpZt7OO1Zp8AFWPZ3p8Cahq8536fD8RiBES9jRsvChZvOqA7gMcFc4"
+		"YD0iZhNIcI7a654u5yPYyTlf5kjR97prCf_OXWRn-bYY74zna4p_bP9oWCL4BkaoRcMxi-IR7kmVcCnvbYqyIrKloXP2qPO442RBGqU7Ov9"
+		"sGQxiVqtRHKXZR9RbfvjrErY1KGiCp9M5i2bsUHadZEY44FE2jiOmx-uc2z5c05CCXqVSpfCjWbh9gQ",
+		token);
+}
+
 #if !defined(JWT_OPENSSL_1_0_0)
 TEST(TokenTest, CreateTokenRS256Encrypted) {
 	// openssl genrsa -aes256 -out private.pem 2048
@@ -329,6 +341,23 @@ TEST(TokenTest, VerifyTokenRS256) {
 	verify.verify(decoded_token);
 }
 
+TEST(TokenTest, VerifyTokenEvpPkeyRS256) {
+	std::string token =
+		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.VA2i1ui1cnoD6I3wnji1WAVCf29EekysvevGrT2GXqK1dDMc8"
+		"HAZCTQxa1Q8NppnpYV-hlqxh-X3Bb0JOePTGzjynpNZoJh2aHZD-GKpZt7OO1Zp8AFWPZ3p8Cahq8536fD8RiBES9jRsvChZvOqA7gMcFc4"
+		"YD0iZhNIcI7a654u5yPYyTlf5kjR97prCf_OXWRn-bYY74zna4p_bP9oWCL4BkaoRcMxi-IR7kmVcCnvbYqyIrKloXP2qPO442RBGqU7Ov9"
+		"sGQxiVqtRHKXZR9RbfvjrErY1KGiCp9M5i2bsUHadZEY44FE2jiOmx-uc2z5c05CCXqVSpfCjWbh9gQ";
+
+	auto verify = jwt::verify()
+					  .allow_algorithm(jwt::algorithm::rsa(jwt::helper::load_private_key_from_string(rsa_priv_key),
+														   EVP_sha256, "RS256"))
+					  .with_issuer("auth0");
+
+	auto decoded_token = jwt::decode(token);
+
+	verify.verify(decoded_token);
+}
+
 TEST(TokenTest, VerifyTokenRS256PublicOnly) {
 	std::string token =
 		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.VA2i1ui1cnoD6I3wnji1WAVCf29EekysvevGrT2GXqK1dDMc8"
@@ -337,6 +366,23 @@ TEST(TokenTest, VerifyTokenRS256PublicOnly) {
 		"sGQxiVqtRHKXZR9RbfvjrErY1KGiCp9M5i2bsUHadZEY44FE2jiOmx-uc2z5c05CCXqVSpfCjWbh9gQ";
 
 	auto verify = jwt::verify().allow_algorithm(jwt::algorithm::rs256(rsa_pub_key, "", "", "")).with_issuer("auth0");
+
+	auto decoded_token = jwt::decode(token);
+
+	verify.verify(decoded_token);
+}
+
+TEST(TokenTest, VerifyTokenEvpPkeyRS256PublicOnly) {
+	std::string token =
+		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXUyJ9.eyJpc3MiOiJhdXRoMCJ9.VA2i1ui1cnoD6I3wnji1WAVCf29EekysvevGrT2GXqK1dDMc8"
+		"HAZCTQxa1Q8NppnpYV-hlqxh-X3Bb0JOePTGzjynpNZoJh2aHZD-GKpZt7OO1Zp8AFWPZ3p8Cahq8536fD8RiBES9jRsvChZvOqA7gMcFc4"
+		"YD0iZhNIcI7a654u5yPYyTlf5kjR97prCf_OXWRn-bYY74zna4p_bP9oWCL4BkaoRcMxi-IR7kmVcCnvbYqyIrKloXP2qPO442RBGqU7Ov9"
+		"sGQxiVqtRHKXZR9RbfvjrErY1KGiCp9M5i2bsUHadZEY44FE2jiOmx-uc2z5c05CCXqVSpfCjWbh9gQ";
+
+	auto verify = jwt::verify()
+					  .allow_algorithm(jwt::algorithm::rsa(jwt::helper::load_public_key_from_string(rsa_pub_key),
+														   EVP_sha256, "RS256"))
+					  .with_issuer("auth0");
 
 	auto decoded_token = jwt::decode(token);
 


### PR DESCRIPTION
I have a use case where I already have the private key represented as an openssl EVP_PKEY instace. Currently an alogrithm constructor for passing such an object directly is missing.