### PR TITLE
:arrow_up: Update Thalhammer/patch-generator-action

### DIFF
--- a/.github/actions/process-linting-results/action.yml
+++ b/.github/actions/process-linting-results/action.yml
@@ -11,7 +11,7 @@ runs:
       shell: bash
     - id: stage
       #continue-on-error: true
-      uses: Thalhammer/patch-generator-action@v2
+      uses: Thalhammer/patch-generator-action@v3
       
     # Unfortunately the previous action reports a failure so nothing else can run
     # partially a limitation on composite actions since `continue-on-error` is not


### PR DESCRIPTION
`actions/upload-artifact@v3` got deprecated/disabled, which required a new version of `Thalhammer/patch-generator-action`.