### PR TITLE
update trait dependencies to support CMake v4

### DIFF
--- a/.github/actions/install/nlohmann-json/action.yml
+++ b/.github/actions/install/nlohmann-json/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: The desired nlohmann-json version to install
     required: false
-    default: "3.11.2"
+    default: "3.12.0"
 runs:
   using: composite
   steps:

--- a/.github/actions/install/open-source-parsers-jsoncpp/action.yml
+++ b/.github/actions/install/open-source-parsers-jsoncpp/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: The desired open-source-parsers/jsoncpp version to install
     required: false
-    default: "1.9.5"
+    default: "1.9.6"
 runs:
   using: composite
   steps:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -259,6 +259,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.25.0"  # <--= optional, use most recent 3.25.x version
 
       - name: setup
         run: |

--- a/.github/workflows/traits.yml
+++ b/.github/workflows/traits.yml
@@ -17,7 +17,7 @@ jobs:
           - { name: "boost-json", tag: "1.78.0", version: "v1.80.0" }
           - { name: "nlohmann-json", tag: "3.12.0", version: "v3.12.0" }
           - { name: "kazuho-picojson", tag: "111c9be5188f7350c2eac9ddaedd8cca3d7bf394", version: "111c9be" }
-          - { name: "open-source-parsers-jsoncpp", tag: "1.9.5", version: "v1.9.5" }
+          - { name: "open-source-parsers-jsoncpp", tag: "1.9.6", version: "v1.9.6" }
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest

--- a/.github/workflows/traits.yml
+++ b/.github/workflows/traits.yml
@@ -15,7 +15,7 @@ jobs:
         target:
           - { name: "danielaparker-jsoncons", tag: "0.168.7", version: "v0.168.7" }
           - { name: "boost-json", tag: "1.78.0", version: "v1.80.0" }
-          - { name: "nlohmann-json", tag: "3.11.2", version: "v3.11.2" }
+          - { name: "nlohmann-json", tag: "3.12.0", version: "v3.12.0" }
           - { name: "kazuho-picojson", tag: "111c9be5188f7350c2eac9ddaedd8cca3d7bf394", version: "111c9be" }
           - { name: "open-source-parsers-jsoncpp", tag: "1.9.5", version: "v1.9.5" }
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if(JWT_BUILD_EXAMPLES OR JWT_BUILD_TESTS)
     include(FetchContent)
     fetchcontent_declare(nlohmann_json
       URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
-      URL_MD5 127794b2c82c0c5693805feaa2a703e2)
+      URL_MD5 e155202b2a589137f6804724bd182f12)
     fetchcontent_makeavailable(nlohmann_json)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(JWT_BUILD_EXAMPLES OR JWT_BUILD_TESTS)
     message(STATUS "jwt-cpp: using FetchContent for nlohmann-json required for tests")
     include(FetchContent)
     fetchcontent_declare(nlohmann_json
-      URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz
+      URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
       URL_MD5 127794b2c82c0c5693805feaa2a703e2)
     fetchcontent_makeavailable(nlohmann_json)
   endif()


### PR DESCRIPTION
New min requirements for CMake V4 policy changes

- nlohmann-json: v3.12.0
- open-source-parsers-jsoncpp: v1.9.6

Downgraded Hunter to CMake V3 