### PR TITLE
Fix error in CMake config-file package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(${JWT_SSL_LIBRARY} MATCHES "wolfSSL")
 endif()
 
 if(NOT JWT_DISABLE_PICOJSON AND JWT_EXTERNAL_PICOJSON)
-  target_link_libraries(jwt-cpp INTERFACE picojson::picojson>)
+  target_link_libraries(jwt-cpp INTERFACE picojson::picojson)
 endif()
 
 # Hunter needs relative paths so the files are placed correctly


### PR DESCRIPTION
### Commit

* Remove greater than sign from link interface

Fixes error
```
  The link interface of target "jwt-cpp::jwt-cpp" contains:

    picojson::picojson>

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```