### PR TITLE
CMake: synchronize cmake_minimum_required from main CMakeLists.txt

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 project(jwt-cpp-examples)
 
 if(NOT TARGET jwt-cpp)

--- a/example/traits/CMakeLists.txt
+++ b/example/traits/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 project(jwt-cpp-traits)
 
 if(NOT TARGET jwt-cpp)

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.14)
 project(jwt-cpp-installation-tests)
 
 set(TEST CACHE STRING "The test source file to be used")


### PR DESCRIPTION
The examples have been using older cmake_minimum_required, given support for versions <3.10 is deprecated since 3.31, synchronize the minimum required version from the main CMakeLists.txt (version 3.14) into examples and tests.

closes #397