### PR TITLE
Reduce usage of std::time_t, std::chrono::system_clock::to_time_t and system_clock::from_time_t in order to get correct dates when working with a 32bit application

### DIFF
--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -2610,7 +2610,8 @@ namespace jwt {
 
 		JWT_CLAIM_EXPLICIT basic_claim(typename json_traits::string_type s) : val(std::move(s)) {}
 		JWT_CLAIM_EXPLICIT basic_claim(const date& d)
-			: val(typename json_traits::integer_type(std::chrono::system_clock::to_time_t(d))) {}
+			: val(typename json_traits::integer_type(
+				  std::chrono::duration_cast<std::chrono::seconds>(d.time_since_epoch()).count())) {}
 		JWT_CLAIM_EXPLICIT basic_claim(typename json_traits::array_type a) : val(std::move(a)) {}
 		JWT_CLAIM_EXPLICIT basic_claim(typename json_traits::value_type v) : val(std::move(v)) {}
 		JWT_CLAIM_EXPLICIT basic_claim(const set_t& s) : val(typename json_traits::array_type(s.begin(), s.end())) {}
@@ -2659,9 +2660,8 @@ namespace jwt {
 		 */
 		date as_date() const {
 			using std::chrono::system_clock;
-			if (get_type() == json::type::number)
-				return system_clock::from_time_t(static_cast<std::time_t>(std::round(as_number())));
-			return system_clock::from_time_t(static_cast<std::time_t>(as_integer()));
+			if (get_type() == json::type::number) return date(std::chrono::seconds(std::llround(as_number())));
+			return date(std::chrono::seconds(as_integer()));
 		}
 
 		/**


### PR DESCRIPTION
Fixing a potential "year 2038 problem" occurrence in "jwt.h".
This one seems to happen when using the library in 32-bit applications. The main problem is not the architecture itself, but the usage of "std::time_t" from "<ctime>" instead of chrono-only utils in the "jwt-cpp" library.

I've added an example here in which the difference between 32-bit and 64-bit compilation can be seen clearly:

1. Create token with "exp" of different dates
2. Convert data to string
3. Convert string to data
4. See that "exp" (for year >2038) gets negative --> Which means basically "token expired"

https://godbolt.org/z/9GGqM577W

Code:

```cpp
#include <chrono>
#include <iostream>

#include "jwt-cpp/jwt.h"

void analyze(std::chrono::hours hours_from_now)
{
    std::string token = jwt::create().set_expires_at(std::chrono::system_clock::now() + hours_from_now).sign(jwt::algorithm::none{});
    std::chrono::system_clock::time_point exp = jwt::decode(token).get_expires_at();

    std::cout << std::chrono::duration_cast<std::chrono::seconds>(exp.time_since_epoch()).count() << "\n";
}

int main()
{
    // Testing conversion of token with "exp" to string and back to data again
    std::cout << "Tests:\n";
    analyze(std::chrono::hours(24 * 365 * 0));  // Today
    analyze(std::chrono::hours(24 * 365 * 1));  // Today + 1 year
    analyze(std::chrono::hours(24 * 365 * 10)); // Today + 10 years
    analyze(std::chrono::hours(24 * 365 * 20)); // Today + 20 years (Potential "year 2038 problem")

    // Looking onto the problem:

    // Today + 20 years (Potential "year 2038 problem")
    const auto problematic_time_point = std::chrono::system_clock::now() + std::chrono::hours(24 * 365 * 20);

    // When converting to "std::time_t" (And so using <ctime>)
    std::cout << "\nSee problem:\n";
    long long time1 = std::chrono::system_clock::to_time_t(problematic_time_point);
    std::cout << time1 << "\n";

    // When converting to "std::chrono::duration_cast" (Using <chrono> only)
    std::cout << "\nSee solution:\n";
    long long time2 = std::chrono::duration_cast<std::chrono::seconds>(problematic_time_point.time_since_epoch()).count();
    std::cout << time2 << "\n";

    return 0;
}
```

Result (32-bit):
```
Tests:
1763856625
1795392625
2079216625
-1900390671

See problem:
-1900390671

See solution:
2394576625
```

Result (64-bit):
```
Tests:
1763856626
1795392626
2079216626
2394576626

See problem:
2394576626

See solution:
2394576626
```