### PR TITLE
Fix `set_expires_in` not accepting non-default `Period`

### DIFF
--- a/example/rsa-create.cpp
+++ b/example/rsa-create.cpp
@@ -37,7 +37,7 @@ rK0/Ikt5ybqUzKCMJZg2VKGTxg==
 					 .set_type("JWT")
 					 .set_id("rsa-create-example")
 					 .set_issued_now()
-					 .set_expires_in(std::chrono::seconds{36000})
+					 .set_expires_in(std::chrono::hours{1})
 					 .set_payload_claim("sample", jwt::claim(std::string{"test"}))
 					 .sign(jwt::algorithm::rs256("", rsa_priv_key, "", ""));
 

--- a/include/jwt-cpp/jwt.h
+++ b/include/jwt-cpp/jwt.h
@@ -3246,8 +3246,8 @@ namespace jwt {
 		 * \param d token expiration timeout
 		 * \return *this to allow for method chaining
 		 */
-		template<class Rep>
-		builder& set_expires_in(const std::chrono::duration<Rep>& d) {
+		template<class Rep, class Period>
+		builder& set_expires_in(const std::chrono::duration<Rep, Period>& d) {
 			return set_payload_claim("exp", basic_claim<json_traits>(clock.now() + d));
 		}
 		/**

--- a/tests/traits/BoostJsonTest.cpp
+++ b/tests/traits/BoostJsonTest.cpp
@@ -87,7 +87,7 @@ TEST(BoostJsonTest, VerifyTokenExpirationInValid) {
 	const auto token = jwt::create<jwt::traits::boost_json>()
 						   .set_issuer("auth0")
 						   .set_issued_now()
-						   .set_expires_in(std::chrono::seconds{3600})
+						   .set_expires_in(std::chrono::hours{1})
 						   .sign(jwt::algorithm::hs256{"secret"});
 
 	const auto decoded_token = jwt::decode<jwt::traits::boost_json>(token);

--- a/tests/traits/JsonconsTest.cpp
+++ b/tests/traits/JsonconsTest.cpp
@@ -90,7 +90,7 @@ TEST(JsonconsTest, VerifyTokenExpirationInValid) {
 	const auto token = jwt::create<jwt::traits::danielaparker_jsoncons>()
 						   .set_issuer("auth0")
 						   .set_issued_now()
-						   .set_expires_in(std::chrono::seconds{3600})
+						   .set_expires_in(std::chrono::hours{1})
 						   .sign(jwt::algorithm::hs256{"secret"});
 
 	const auto decoded_token = jwt::decode<jwt::traits::danielaparker_jsoncons>(token);

--- a/tests/traits/NlohmannTest.cpp
+++ b/tests/traits/NlohmannTest.cpp
@@ -86,7 +86,7 @@ TEST(NlohmannTest, VerifyTokenExpirationInValid) {
 	const auto token = jwt::create<jwt::traits::nlohmann_json>()
 						   .set_issuer("auth0")
 						   .set_issued_now()
-						   .set_expires_in(std::chrono::seconds{3600})
+						   .set_expires_in(std::chrono::hours{1})
 						   .sign(jwt::algorithm::hs256{"secret"});
 
 	const auto decoded_token = jwt::decode<jwt::traits::nlohmann_json>(token);

--- a/tests/traits/OspJsoncppTest.cpp
+++ b/tests/traits/OspJsoncppTest.cpp
@@ -90,7 +90,7 @@ TEST(OspJsoncppTest, VerifyTokenExpirationInValid) {
 	const auto token = jwt::create<jwt::traits::open_source_parsers_jsoncpp>()
 						   .set_issuer("auth0")
 						   .set_issued_now()
-						   .set_expires_in(std::chrono::seconds{3600})
+						   .set_expires_in(std::chrono::hours{1})
 						   .sign(jwt::algorithm::hs256{"secret"});
 
 	const auto decoded_token = jwt::decode<jwt::traits::open_source_parsers_jsoncpp>(token);

--- a/tests/traits/TraitsTest.cpp.mustache
+++ b/tests/traits/TraitsTest.cpp.mustache
@@ -90,7 +90,7 @@ TEST({{test_suite_name}}, VerifyTokenExpirationInValid) {
 	const auto token = jwt::create<jwt::traits::{{traits_name}}>()
 						   .set_issuer("auth0")
 						   .set_issued_now()
-						   .set_expires_in(std::chrono::seconds{3600})
+						   .set_expires_in(std::chrono::hours{1})
 						   .sign(jwt::algorithm::hs256{"secret"});
 
 	const auto decoded_token = jwt::decode<jwt::traits::{{traits_name}}>(token);


### PR DESCRIPTION
Hello there!

Some time ago, I implemented the `set_expires_in` method (https://github.com/Thalhammer/jwt-cpp/pull/322) and forgot to check whether values ​​of type `duration` other than `seconds` could be passed as arguments.

I forgot to add a second parameter to the `Period` template type, so the `duration` type with a non-standard `Period` value couldn't be matched with the method signature.

This pull request adds the missing template parameter and replaces `seconds` with `hours` in tests and some examples. Some examples using `seconds` still remain.