### PR TITLE
Bump OpenSSL versions in CI configuration and documentation

### DIFF
--- a/.github/workflows/ssl.yml
+++ b/.github/workflows/ssl.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         openssl:
-          - { tag: "openssl-3.0.5", name: "3.0.5" }
+          - { tag: "openssl-3.0.19", name: "3.0.19" }
+          - { tag: "openssl-3.5.5", name: "3.5.5" }
+          - { tag: "openssl-3.6.1", name: "3.6.1" }
           - { tag: "OpenSSL_1_1_1q", name: "1.1.1q" }
           - { tag: "OpenSSL_1_1_0i", name: "1.1.0i" } # Do not bump, there's a broken in the autoconfig script and it's not maintained
           - { tag: "OpenSSL_1_0_2u", name: "1.0.2u" }
@@ -40,14 +42,14 @@ jobs:
 
   openssl-no-deprecated:
     runs-on: ubuntu-latest
-    name: OpenSSL 3.0 No Deprecated
+    name: OpenSSL 3.6 No Deprecated
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: ./.github/actions/install/gtest
       - uses: ./.github/actions/install/openssl
         with:
-          version: "openssl-3.0.5"
+          version: "openssl-3.6.1"
 
       - name: configure
         run: cmake --preset unit-tests -DOPENSSL_ROOT_DIR=/tmp -DCMAKE_CXX_FLAGS="-DOPENSSL_NO_DEPRECATED=1" -DCMAKE_C_FLAGS="-DOPENSSL_NO_DEPRECATED=1"

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -14,22 +14,28 @@ cmake . -DJWT_SSL_LIBRARY:STRING=wolfSSL
 
 ## Supported Versions
 
-These are the version which are currently being tested:
+These are the versions which are currently being tested:
 
 | OpenSSL           | LibreSSL       | wolfSSL        |
 | ----------------- | -------------- | -------------- |
-| ![1.0.2u][o1.0.2] | ![3.3.6][l3.3] | ![5.1.1][w5.1] |
-| ![1.1.0i][o1.1.0] | ![3.4.3][l3.4] | ![5.2.0][w5.2] |
-| ![1.1.1q][o1.1.1] | ![3.5.3][l3.5] | ![5.3.0][w5.3] |
-| ![3.0.5][o3.0]    |                |                |
+| ![3.0.19][o3.0]   | ![3.3.6][l3.3] | ![5.1.1][w5.1] |
+| ![3.5.5][o3.5] :star: | ![3.4.3][l3.4] | ![5.2.0][w5.2] |
+| ![3.6.1][o3.6]    | ![3.5.3][l3.5] | ![5.3.0][w5.3] |
 
 > [!NOTE]
+> :star: Indicates LTS (Long-Term Support) versions. [OpenSSL versions](https://openssl-library.org/policies/releasestrat/index.html) are supported as follows:
+> - **3.0.19**: Supported until 2026-09-07 (LTS)
+> - **3.5.5**: Supported until 2030-04-08 (LTS)
+> - **3.6.1**: Supported until 2026-11-01
+>
 > A complete list of versions tested in the past can be found [here](https://github.com/Thalhammer/jwt-cpp/tree/badges).
 
 [o1.0.2]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/1.0.2u/shields.json
 [o1.1.0]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/1.1.0i/shields.json
 [o1.1.1]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/1.1.1q/shields.json
-[o3.0]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/3.0.5/shields.json
+[o3.0]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/3.0.19/shields.json
+[o3.5]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/3.5.5/shields.json
+[o3.6]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/openssl/3.6.1/shields.json
 [l3.3]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.3.6/shields.json
 [l3.4]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.4.3/shields.json
 [l3.5]: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Thalhammer/jwt-cpp/badges/libressl/3.5.3/shields.json


### PR DESCRIPTION
Update to the latest LTS 3.0 and 3.5 plus the current 3.6 release